### PR TITLE
Add functions to express dimensioned quantities.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+
+# A non-recursive make-file, in the excellent style proposed by Emile van Bergen
+# at http://evbergen.home.xs4all.nl/nonrecursive-make.html
+
+# Disable built-in implicit rules.  We don't need them.
+.SUFFIXES:
+
+# Each recipe is passed directly to a single shell invocation, rather than one
+# invocation per line.
+.ONESHELL:
+
+# Push the current directory onto the directory stack.
+sp             := $(sp).x
+dirstack_$(sp) := $(d)
+d              := $(dir)
+
+# Define openscad executable name.
+OSCAD := openscad
+OSCAD_TEST := $(OSCAD) --render
+
+# Subdirectories, in random order.
+dir := test
+include $(dir)/rules.mk
+
+# Makefile fragments should append any test targets to TESTS
+
+# The test target runs all tests.
+.PHONY: test
+test: $(TESTS)
+
+# Pop the directory stack.
+d  := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/bearing.scad
+++ b/bearing.scad
@@ -14,13 +14,13 @@ include <materials.scad>
 
 module test_bearing(){
     bearing();
-    bearing(pos=[5*cm, 0,0], angle=[90,0,0]);
-    bearing(pos=[-2.5*cm, 0,0], model=688);
+    bearing(pos=[cm(5), 0,0], angle=[90,0,0]);
+    bearing(pos=[cm(-2.5), 0,0], model=688);
 }
 
 module test_bearing_hole(){
     difference(){
-      translate([0, 0, 3.5]) cube(size=[30, 30, 7-10*epsilon], center=true);
+      translate([0, 0, 3.5]) cube(size=[30, 30, 7-10*MCAD_EPSILON], center=true);
       bearing(outline=true);
     }
 }
@@ -35,13 +35,13 @@ SkateBearing = 608;
 // Bearing dimensions
 // model == XXX ? [inner dia, outer dia, width]:
 function bearingDimensions(model) =
-  model == 608 ? [8*mm, 22*mm, 7*mm]:
-  model == 623 ? [3*mm, 10*mm, 4*mm]:
-  model == 624 ? [4*mm, 13*mm, 5*mm]:
-  model == 627 ? [7*mm, 22*mm, 7*mm]:
-  model == 688 ? [8*mm, 16*mm, 4*mm]:
-  model == 698 ? [8*mm, 19*mm, 6*mm]:
-  [8*mm, 22*mm, 7*mm]; // this is the default
+  model == 608 ? [mm(8), mm(22), mm(7)]:
+  model == 623 ? [mm(3), mm(10), mm(4)]:
+  model == 624 ? [mm(4), mm(13), mm(5)]:
+  model == 627 ? [mm(7), mm(22), mm(7)]:
+  model == 688 ? [mm(8), mm(16), mm(4)]:
+  model == 698 ? [mm(8), mm(19), mm(6)]:
+  [mm(8), mm(22), mm(7)]; // this is the default
 
 
 function bearingWidth(model) = bearingDimensions(model)[BEARING_WIDTH];
@@ -71,8 +71,8 @@ module bearing(pos=[0,0,0], angle=[0,0,0], model=SkateBearing, outline=false,
 
         if (outline==false) {
           // Side shields
-          Ring([0,0,-epsilon], outerRim, innerRim, epsilon+midSink, sideMaterial, material);
-          Ring([0,0,w-midSink], outerRim, innerRim, epsilon+midSink, sideMaterial, material);
+          Ring([0,0,-MCAD_EPSILON], outerRim, innerRim, MCAD_EPSILON+midSink, sideMaterial, material);
+          Ring([0,0,w-midSink], outerRim, innerRim, MCAD_EPSILON+midSink, sideMaterial, material);
         }
       }
   }
@@ -83,8 +83,8 @@ module bearing(pos=[0,0,0], angle=[0,0,0], model=SkateBearing, outline=false,
         difference() {
           cylinder(r=od/2, h=h,  $fs = 0.01);
           color(holeMaterial)
-            translate([0,0,-10*epsilon])
-              cylinder(r=id/2, h=h+20*epsilon,  $fs = 0.01);
+            translate([0,0,-10*MCAD_EPSILON])
+              cylinder(r=id/2, h=h+20*MCAD_EPSILON,  $fs = 0.01);
         }
     }
   }

--- a/constants.scad
+++ b/constants.scad
@@ -3,7 +3,3 @@
 
 TAU = 6.2831853071; //2*PI, see http://tauday.com/
 PI = TAU/2;
-
-// translates a imperial measurement in inches to meters
-mm_per_inch = 25.4;
-

--- a/gridbeam.scad
+++ b/gridbeam.scad
@@ -29,12 +29,12 @@ mode = "model";
 
 include <units.scad>
 
-beam_width = inch * 1.5;
-beam_hole_diameter = inch * 5/16;
+beam_width = inch(1.5);
+beam_hole_diameter = inch(5/16);
 beam_hole_radius = beam_hole_diameter / 2;
 beam_is_hollow = 1;
-beam_wall_thickness = inch * 1/8;
-beam_shelf_thickness = inch * 1/4;
+beam_wall_thickness = inch(1/8);
+beam_shelf_thickness = inch(1/4);
 
 module zBeam(segments) {
 if (mode == "model") {

--- a/motors.scad
+++ b/motors.scad
@@ -3,7 +3,7 @@
 // This library is dual licensed under the GPL 3.0 and the GNU Lesser General Public License as per http://creativecommons.org/licenses/LGPL/2.1/ .
 
 include <math.scad>
-
+include <units.scad>
 
 //generates a motor mount for the specified nema standard #.
 module stepper_motor_mount(nema_standard,slide_distance=0, mochup=true, tolerance=0) {
@@ -12,30 +12,31 @@ module stepper_motor_mount(nema_standard,slide_distance=0, mochup=true, toleranc
 	if (nema_standard == 17)
 	{
 		_stepper_motor_mount(
-			motor_shaft_diameter = 0.1968*mm_per_inch,
-			motor_shaft_length = 0.945*mm_per_inch,
-			pilot_diameter = 0.866*mm_per_inch,
-			pilot_length = 0.80*mm_per_inch,
-			mounting_bolt_circle = 1.725*mm_per_inch,
-			bolt_hole_size = 3.5,
-			bolt_hole_distance = 1.220*mm_per_inch,
-			slide_distance = slide_distance,
+			motor_shaft_diameter = inch(0.1968),
+			motor_shaft_length   = inch(0.945),
+			pilot_diameter       = inch(0.866),
+			pilot_length         = inch(0.80),
+			mounting_bolt_circle = inch(1.725),
+			bolt_hole_size       =   mm(3.5),
+			bolt_hole_distance   = inch(1.220),
+			slide_distance       = slide_distance,
 			mochup = mochup,
 			tolerance=tolerance);
 	}
 	if (nema_standard == 23)
 	{
 		_stepper_motor_mount(
-			motor_shaft_diameter = 0.250*mm_per_inch,
-			motor_shaft_length = 0.81*mm_per_inch,
-			pilot_diameter = 1.500*mm_per_inch,
-			pilot_length = 0.062*mm_per_inch,
-			mounting_bolt_circle = 2.625*mm_per_inch,
-			bolt_hole_size = 0.195*mm_per_inch,
-			bolt_hole_distance = 1.856*mm_per_inch,
-			slide_distance = slide_distance,
-			mochup = mochup,
-			tolerance=tolerance);
+			motor_shaft_diameter   = inch(0.250),
+			motor_shaft_length     = inch(0.81),
+			pilot_diameter         = inch(1.500),
+			pilot_length           = inch(0.062),
+			mounting_bolt_circle   = inch(2.625),
+			bolt_hole_size         = inch(0.195),
+			bolt_hole_distance     = inch(1.856),
+			slide_distance         = slide_distance,
+			mochup                 = mochup,
+			tolerance              = tolerance
+        );
 	}
 	
 }

--- a/nuts_and_bolts.scad
+++ b/nuts_and_bolts.scad
@@ -2,6 +2,8 @@
 
 // This library is dual licensed under the GPL 3.0 and the GNU Lesser General Public License as per http://creativecommons.org/licenses/LGPL/2.1/ .
 
+include <units.scad>
+
 //testNutsAndBolts();
 
 module SKIPtestNutsAndBolts()
@@ -20,80 +22,80 @@ METRIC_NUT_AC_WIDTHS =
 	-1, //0 index is not used but reduces computation
 	-1,
 	-1,
-	6.40,//m3
-	8.10,//m4
-	9.20,//m5
-	11.50,//m6
+	mm(6.40),//m3
+	mm(8.10),//m4
+	mm(9.20),//m5
+	mm(11.50),//m6
 	-1,
-	15.00,//m8
+	mm(15.00),//m8
 	-1,
-	19.60,//m10
+	mm(19.60),//m10
 	-1,
-	22.10,//m12
-	-1,
-	-1,
-	-1,
-	27.70,//m16
+	mm(22.10),//m12
 	-1,
 	-1,
 	-1,
-	34.60,//m20
+	mm(27.70),//m16
 	-1,
 	-1,
 	-1,
-	41.60,//m24
+	mm(34.60),//m20
 	-1,
 	-1,
 	-1,
-	-1,
-	-1,
-	53.1,//m30
+	mm(41.60),//m24
 	-1,
 	-1,
 	-1,
 	-1,
 	-1,
-	63.5//m36
+	mm(53.1),//m30
+	-1,
+	-1,
+	-1,
+	-1,
+	-1,
+	mm(63.5)//m36
 ];
 METRIC_NUT_THICKNESS =
 [
 	-1, //0 index is not used but reduces computation
 	-1,
 	-1,
-	2.40,//m3
-	3.20,//m4
-	4.00,//m5
-	5.00,//m6
+	mm(2.40),//m3
+	mm(3.20),//m4
+	mm(4.00),//m5
+	mm(5.00),//m6
 	-1,
-	6.50,//m8
+	mm(6.50),//m8
 	-1,
-	8.00,//m10
+	mm(8.00),//m10
 	-1,
-	10.00,//m12
-	-1,
-	-1,
-	-1,
-	13.00,//m16
+	mm(10.00),//m12
 	-1,
 	-1,
 	-1,
-	16.00//m20
+	mm(13.00),//m16
 	-1,
 	-1,
 	-1,
-	19.00,//m24
+	mm(16.00)//m20
 	-1,
 	-1,
 	-1,
-	-1,
-	-1,
-	24.00,//m30
+	mm(19.00),//m24
 	-1,
 	-1,
 	-1,
 	-1,
 	-1,
-	29.00//m36
+	mm(24.00),//m30
+	-1,
+	-1,
+	-1,
+	-1,
+	-1,
+	mm(29.00)//m36
 ];
 
 COURSE_METRIC_BOLT_MAJOR_THREAD_DIAMETERS =
@@ -101,40 +103,40 @@ COURSE_METRIC_BOLT_MAJOR_THREAD_DIAMETERS =
 	-1, //0 index is not used but reduces computation
 	-1,
 	-1,
-	2.98,//m3
-	3.978,//m4
-	4.976,//m5
-	5.974,//m6
+	mm(2.98),//m3
+	mm(3.978),//m4
+	mm(4.976),//m5
+	mm(5.974),//m6
 	-1,
-	7.972,//m8
+	mm(7.972),//m8
 	-1,
-	9.968,//m10
+	mm(9.968),//m10
 	-1,
-	11.966,//m12
-	-1,
-	-1,
-	-1,
-	15.962,//m16
+	mm(11.966),//m12
 	-1,
 	-1,
 	-1,
-	19.958,//m20
+	mm(15.962),//m16
 	-1,
 	-1,
 	-1,
-	23.952,//m24
+	mm(19.958),//m20
 	-1,
 	-1,
 	-1,
-	-1,
-	-1,
-	29.947,//m30
+	mm(23.952),//m24
 	-1,
 	-1,
 	-1,
 	-1,
 	-1,
-	35.940//m36
+	mm(29.947),//m30
+	-1,
+	-1,
+	-1,
+	-1,
+	-1,
+	mm(35.940)//m36
 ];
 
 module nutHole(size, units=MM, tolerance = +0.0001, proj = -1)

--- a/stepper.scad
+++ b/stepper.scad
@@ -56,134 +56,134 @@ NemaLong = NemaC;
 // TODO: The small motors seem to be a bit too long, I picked the size specs from all over the place, is there some canonical reference?
 Nema08 = [
                 [NemaModel, 8],
-                [NemaLengthShort, 33*mm],
-                [NemaLengthMedium, 43*mm],
-                [NemaLengthLong, 43*mm],
-                [NemaSideSize, 20*mm], 
-                [NemaDistanceBetweenMountingHoles, 15.4*mm], 
-                [NemaMountingHoleDiameter, 2*mm], 
-                [NemaMountingHoleDepth, 1.75*mm], 
-                [NemaMountingHoleLip, -1*mm], 
-                [NemaMountingHoleCutoutRadius, 0*mm], 
-                [NemaEdgeRoundingRadius, 2*mm], 
-                [NemaRoundExtrusionDiameter, 16*mm], 
-                [NemaRoundExtrusionHeight, 1.5*mm], 
-                [NemaAxleDiameter, 4*mm], 
-                [NemaFrontAxleLength, 13.5*mm], 
-                [NemaBackAxleLength, 9.9*mm],
-                [NemaAxleFlatDepth, -1*mm],
-                [NemaAxleFlatLengthFront, 0*mm],
-                [NemaAxleFlatLengthBack, 0*mm]
+                [NemaLengthShort,                  mm( 33    )],
+                [NemaLengthMedium,                 mm( 43    )],
+                [NemaLengthLong,                   mm( 43    )],
+                [NemaSideSize,                     mm( 20    )],
+                [NemaDistanceBetweenMountingHoles, mm( 15.4  )],
+                [NemaMountingHoleDiameter,         mm(  2    )],
+                [NemaMountingHoleDepth,            mm(  1.75 )],
+                [NemaMountingHoleLip,              mm(- 1    )],
+                [NemaMountingHoleCutoutRadius,     mm(  0    )],
+                [NemaEdgeRoundingRadius,           mm(  2    )],
+                [NemaRoundExtrusionDiameter,       mm( 16    )],
+                [NemaRoundExtrusionHeight,         mm(  1.5  )],
+                [NemaAxleDiameter,                 mm(  4    )],
+                [NemaFrontAxleLength,              mm( 13.5  )],
+                [NemaBackAxleLength,               mm(  9.9  )],
+                [NemaAxleFlatDepth,                mm(- 1    )],
+                [NemaAxleFlatLengthFront,          mm(  0    )],
+                [NemaAxleFlatLengthBack,           mm(  0    )]
          ];
 
 Nema11 = [
                 [NemaModel, 11],
-                [NemaLengthShort, 32*mm],
-                [NemaLengthMedium, 40*mm],
-                [NemaLengthLong, 52*mm],
-                [NemaSideSize, 28*mm], 
-                [NemaDistanceBetweenMountingHoles, 23*mm], 
-                [NemaMountingHoleDiameter, 2.5*mm], 
-                [NemaMountingHoleDepth, 2*mm], 
-                [NemaMountingHoleLip, -1*mm], 
-                [NemaMountingHoleCutoutRadius, 0*mm], 
-                [NemaEdgeRoundingRadius, 2.5*mm], 
-                [NemaRoundExtrusionDiameter, 22*mm], 
-                [NemaRoundExtrusionHeight, 1.8*mm], 
-                [NemaAxleDiameter, 5*mm], 
-                [NemaFrontAxleLength, 13.7*mm], 
-                [NemaBackAxleLength, 10*mm],
-                [NemaAxleFlatDepth, 0.5*mm],
-                [NemaAxleFlatLengthFront, 10*mm],
-                [NemaAxleFlatLengthBack, 9*mm]
+                [NemaLengthShort,                  mm( 32   )],
+                [NemaLengthMedium,                 mm( 40   )],
+                [NemaLengthLong,                   mm( 52   )],
+                [NemaSideSize,                     mm( 28   )],
+                [NemaDistanceBetweenMountingHoles, mm( 23   )],
+                [NemaMountingHoleDiameter,         mm(  2.5 )],
+                [NemaMountingHoleDepth,            mm(  2   )],
+                [NemaMountingHoleLip,              mm(- 1   )],
+                [NemaMountingHoleCutoutRadius,     mm(  0   )],
+                [NemaEdgeRoundingRadius,           mm(  2.5 )],
+                [NemaRoundExtrusionDiameter,       mm( 22   )],
+                [NemaRoundExtrusionHeight,         mm(  1.8 )],
+                [NemaAxleDiameter,                 mm(  5   )],
+                [NemaFrontAxleLength,              mm( 13.7 )],
+                [NemaBackAxleLength,               mm( 10   )],
+                [NemaAxleFlatDepth,                mm(  0.5 )],
+                [NemaAxleFlatLengthFront,          mm( 10   )],
+                [NemaAxleFlatLengthBack,           mm(  9   )]
          ];
 
 Nema14 = [
                 [NemaModel, 14],
-                [NemaLengthShort, 26*mm], 
-                [NemaLengthMedium, 28*mm], 
-                [NemaLengthLong, 34*mm], 
-                [NemaSideSize, 35.3*mm], 
-                [NemaDistanceBetweenMountingHoles, 26*mm], 
-                [NemaMountingHoleDiameter, 3*mm], 
-                [NemaMountingHoleDepth, 3.5*mm], 
-                [NemaMountingHoleLip, -1*mm], 
-                [NemaMountingHoleCutoutRadius, 0*mm], 
-                [NemaEdgeRoundingRadius, 5*mm], 
-                [NemaRoundExtrusionDiameter, 22*mm], 
-                [NemaRoundExtrusionHeight, 1.9*mm], 
-                [NemaAxleDiameter, 5*mm], 
-                [NemaFrontAxleLength, 18*mm], 
-                [NemaBackAxleLength, 10*mm],
-                [NemaAxleFlatDepth, 0.5*mm],
-                [NemaAxleFlatLengthFront, 15*mm],
-                [NemaAxleFlatLengthBack, 9*mm]
+                [NemaLengthShort,                  mm( 26   )],
+                [NemaLengthMedium,                 mm( 28   )],
+                [NemaLengthLong,                   mm( 34   )],
+                [NemaSideSize,                     mm( 35.3 )],
+                [NemaDistanceBetweenMountingHoles, mm( 26   )],
+                [NemaMountingHoleDiameter,         mm(  3   )],
+                [NemaMountingHoleDepth,            mm(  3.5 )],
+                [NemaMountingHoleLip,              mm(- 1   )],
+                [NemaMountingHoleCutoutRadius,     mm(  0   )],
+                [NemaEdgeRoundingRadius,           mm(  5   )],
+                [NemaRoundExtrusionDiameter,       mm( 22   )],
+                [NemaRoundExtrusionHeight,         mm(  1.9 )],
+                [NemaAxleDiameter,                 mm(  5   )],
+                [NemaFrontAxleLength,              mm( 18   )],
+                [NemaBackAxleLength,               mm( 10   )],
+                [NemaAxleFlatDepth,                mm(  0.5 )],
+                [NemaAxleFlatLengthFront,          mm( 15   )],
+                [NemaAxleFlatLengthBack,           mm(  9   )]
          ];
 
 Nema17 = [
                 [NemaModel, 17],
-                [NemaLengthShort, 33*mm],
-                [NemaLengthMedium, 39*mm],
-                [NemaLengthLong, 47*mm],
-                [NemaSideSize, 42.20*mm], 
-                [NemaDistanceBetweenMountingHoles, 31.04*mm], 
-                [NemaMountingHoleDiameter, 4*mm], 
-                [NemaMountingHoleDepth, 4.5*mm], 
-                [NemaMountingHoleLip, -1*mm], 
-                [NemaMountingHoleCutoutRadius, 0*mm], 
-                [NemaEdgeRoundingRadius, 7*mm], 
-                [NemaRoundExtrusionDiameter, 22*mm], 
-                [NemaRoundExtrusionHeight, 1.9*mm], 
-                [NemaAxleDiameter, 5*mm], 
-                [NemaFrontAxleLength, 18*mm], 
-                [NemaBackAxleLength, 15*mm],
-                [NemaAxleFlatDepth, 0.5*mm],
-                [NemaAxleFlatLengthFront, 15*mm],
-                [NemaAxleFlatLengthBack, 14*mm]
+                [NemaLengthShort,                  mm( 33    )],
+                [NemaLengthMedium,                 mm( 39    )],
+                [NemaLengthLong,                   mm( 47    )],
+                [NemaSideSize,                     mm( 42.20 )],
+                [NemaDistanceBetweenMountingHoles, mm( 31.04 )],
+                [NemaMountingHoleDiameter,         mm(  4    )],
+                [NemaMountingHoleDepth,            mm(  4.5  )],
+                [NemaMountingHoleLip,              mm(- 1    )],
+                [NemaMountingHoleCutoutRadius,     mm(  0    )],
+                [NemaEdgeRoundingRadius,           mm(  7    )],
+                [NemaRoundExtrusionDiameter,       mm( 22    )],
+                [NemaRoundExtrusionHeight,         mm(  1.9  )],
+                [NemaAxleDiameter,                 mm(  5    )],
+                [NemaFrontAxleLength,              mm( 18    )],
+                [NemaBackAxleLength,               mm( 15    )],
+                [NemaAxleFlatDepth,                mm(  0.5  )],
+                [NemaAxleFlatLengthFront,          mm( 15    )],
+                [NemaAxleFlatLengthBack,           mm( 14    )]
          ];
 
 Nema23 = [
                 [NemaModel, 23],
-                [NemaLengthShort, 39*mm],
-                [NemaLengthMedium, 54*mm],
-                [NemaLengthLong, 76*mm],
-                [NemaSideSize, 56.4*mm], 
-                [NemaDistanceBetweenMountingHoles, 47.14*mm], 
-                [NemaMountingHoleDiameter, 4.75*mm], 
-                [NemaMountingHoleDepth, 5*mm], 
-                [NemaMountingHoleLip, 4.95*mm], 
-                [NemaMountingHoleCutoutRadius, 9.5*mm], 
-                [NemaEdgeRoundingRadius, 2.5*mm], 
-                [NemaRoundExtrusionDiameter, 38.10*mm], 
-                [NemaRoundExtrusionHeight, 1.52*mm], 
-                [NemaAxleDiameter, 6.36*mm], 
-                [NemaFrontAxleLength, 18.80*mm], 
-                [NemaBackAxleLength, 15.60*mm],
-                [NemaAxleFlatDepth, 0.5*mm],
-                [NemaAxleFlatLengthFront, 16*mm],
-                [NemaAxleFlatLengthBack, 14*mm]
+                [NemaLengthShort,                  mm( 39    )],
+                [NemaLengthMedium,                 mm( 54    )],
+                [NemaLengthLong,                   mm( 76    )],
+                [NemaSideSize,                     mm( 56.4  )],
+                [NemaDistanceBetweenMountingHoles, mm( 47.14 )],
+                [NemaMountingHoleDiameter,         mm(  4.75 )],
+                [NemaMountingHoleDepth,            mm(  5    )],
+                [NemaMountingHoleLip,              mm(  4.95 )],
+                [NemaMountingHoleCutoutRadius,     mm(  9.5  )],
+                [NemaEdgeRoundingRadius,           mm(  2.5  )],
+                [NemaRoundExtrusionDiameter,       mm( 38.10 )],
+                [NemaRoundExtrusionHeight,         mm(  1.52 )],
+                [NemaAxleDiameter,                 mm(  6.36 )],
+                [NemaFrontAxleLength,              mm( 18.80 )],
+                [NemaBackAxleLength,               mm( 15.60 )],
+                [NemaAxleFlatDepth,                mm(  0.5  )],
+                [NemaAxleFlatLengthFront,          mm( 16    )],
+                [NemaAxleFlatLengthBack,           mm( 14    )]
          ];
 
 Nema34 = [
                 [NemaModel, 34],
-                [NemaLengthShort, 66*mm],
-                [NemaLengthMedium, 96*mm],
-                [NemaLengthLong, 126*mm],
-                [NemaSideSize, 85*mm], 
-                [NemaDistanceBetweenMountingHoles, 69.58*mm], 
-                [NemaMountingHoleDiameter, 6.5*mm], 
-                [NemaMountingHoleDepth, 5.5*mm], 
-                [NemaMountingHoleLip, 5*mm], 
-                [NemaMountingHoleCutoutRadius, 17*mm], 
-                [NemaEdgeRoundingRadius, 3*mm], 
-                [NemaRoundExtrusionDiameter, 73.03*mm], 
-                [NemaRoundExtrusionHeight, 1.9*mm], 
-                [NemaAxleDiameter, 0.5*inch], 
-                [NemaFrontAxleLength, 37*mm], 
-                [NemaBackAxleLength, 34*mm],
-                [NemaAxleFlatDepth, 1.20*mm],
-                [NemaAxleFlatLengthFront, 25*mm],
-                [NemaAxleFlatLengthBack, 25*mm]
+                [NemaLengthShort,                  mm(  66    )],
+                [NemaLengthMedium,                 mm(  96    )],
+                [NemaLengthLong,                   mm( 126    )],
+                [NemaSideSize,                     mm(  85    )],
+                [NemaDistanceBetweenMountingHoles, mm(  69.58 )],
+                [NemaMountingHoleDiameter,         mm(   6.5  )],
+                [NemaMountingHoleDepth,            mm(   5.5  )],
+                [NemaMountingHoleLip,              mm(   5    )],
+                [NemaMountingHoleCutoutRadius,     mm(  17    )],
+                [NemaEdgeRoundingRadius,           mm(   3    )],
+                [NemaRoundExtrusionDiameter,       mm(  73.03 )],
+                [NemaRoundExtrusionHeight,         mm(   1.9  )],
+                [NemaAxleDiameter,               inch(   0.5  )],
+                [NemaFrontAxleLength,              mm(  37    )],
+                [NemaBackAxleLength,               mm(  34    )],
+                [NemaAxleFlatDepth,                mm(   1.20 )],
+                [NemaAxleFlatLengthFront,          mm(  25    )],
+                [NemaAxleFlatLengthBack,           mm(  25    )]
          ];
 
 
@@ -259,20 +259,20 @@ module motor(model=Nema23, size=NemaMedium, dualAxis=false, pos=[0,0,0], orienta
 
           // Bolt holes
           color(stepperAluminum, $fs=holeRadius/8) {
-            translate([mid+holeDist,mid+holeDist,-1*mm]) cylinder(h=holeDepth+1*mm, r=holeRadius);
-            translate([mid-holeDist,mid+holeDist,-1*mm]) cylinder(h=holeDepth+1*mm, r=holeRadius);
-            translate([mid+holeDist,mid-holeDist,-1*mm]) cylinder(h=holeDepth+1*mm, r=holeRadius);
-            translate([mid-holeDist,mid-holeDist,-1*mm]) cylinder(h=holeDepth+1*mm, r=holeRadius);
+            translate([mid+holeDist,mid+holeDist,mm(-1)]) cylinder(h=holeDepth+mm(1), r=holeRadius);
+            translate([mid-holeDist,mid+holeDist,mm(-1)]) cylinder(h=holeDepth+mm(1), r=holeRadius);
+            translate([mid+holeDist,mid-holeDist,mm(-1)]) cylinder(h=holeDepth+mm(1), r=holeRadius);
+            translate([mid-holeDist,mid-holeDist,mm(-1)]) cylinder(h=holeDepth+mm(1), r=holeRadius);
 
           } 
 
           // Grinded flat
           color(stepperAluminum) {
             difference() {
-              translate([-1*mm, -1*mm, -extrSize]) 
-                cube(size=[side+2*mm, side+2*mm, extrSize + 1*mm]);
-              translate([side/2, side/2, -extrSize - 1*mm]) 
-                cylinder(h=4*mm, r=extrRad);
+              translate([mm(-1), mm(-1), -extrSize])
+                cube(size=[side+mm(2), side+mm(2), extrSize + mm(1)]);
+              translate([side/2, side/2, -extrSize - mm(1)])
+                cylinder(h=mm(4), r=extrRad);
             }
           }
 
@@ -282,22 +282,22 @@ module motor(model=Nema23, size=NemaMedium, dualAxis=false, pos=[0,0,0], orienta
       translate([0, 0, extrSize-axleLengthFront]) color(stepperAluminum) 
         difference() {
                      
-          cylinder(h=axleLengthFront + 1*mm , r=axleRadius, $fs=axleRadius/10);
+          cylinder(h=axleLengthFront + mm(1) , r=axleRadius, $fs=axleRadius/10);
 
           // Flat
           if (axleFlatDepth > 0)
-            translate([axleRadius - axleFlatDepth,-5*mm,-extrSize*mm -(axleLengthFront-axleFlatLengthFront)] ) cube(size=[5*mm, 10*mm, axleLengthFront]);
+            translate([axleRadius - axleFlatDepth,mm(-5),-extrSize -(axleLengthFront-axleFlatLengthFront)] ) cube(size=[mm(5), mm(10), axleLengthFront]);
         }
 
         if (dualAxis) {
           translate([0, 0, length+extrSize]) color(stepperAluminum) 
             difference() {
                      
-              cylinder(h=axleLengthBack + 0*mm, r=axleRadius, $fs=axleRadius/10);
+              cylinder(h=axleLengthBack + mm(0), r=axleRadius, $fs=axleRadius/10);
 
               // Flat
               if (axleFlatDepth > 0)
-                translate([axleRadius - axleFlatDepth,-5*mm,(axleLengthBack-axleFlatLengthBack)]) cube(size=[5*mm, 10*mm, axleLengthBack]);
+                translate([axleRadius - axleFlatDepth,mm(-5),(axleLengthBack-axleFlatLengthBack)]) cube(size=[mm(5), mm(10), axleLengthBack]);
           }
 
         }

--- a/test/rules.mk
+++ b/test/rules.mk
@@ -1,0 +1,14 @@
+
+# Push the current directory onto the directory stack.
+sp             := $(sp).x
+dirstack_$(sp) := $(d)
+d              := $(dir)
+
+# Subdirectories, in no particular order.
+dir := $(d)/units.scad
+include $(dir)/rules.mk
+
+# Pop the directory stack.
+d  := $(dirstack_$(sp))
+sp := $(basename $(sp))
+

--- a/test/units.scad/override_cm.scad
+++ b/test/units.scad/override_cm.scad
@@ -1,0 +1,22 @@
+
+// Test user-specified override of MCAD's base unit.
+
+include <../../units.scad>
+
+// Override so that the base unit is centimeters.
+MCAD_BASE_UNIT = MCAD_BASE_UNIT_CM;
+
+// Hopefully, OpenSCAD will eventually gain an assert statement.
+//
+// For now, we use a poor man's assert.  If the condition is true, we emit some
+// geometry.  If the condition is false, we don't.  If we don't emit geometry,
+// OpenSCAD exits with a nonzero return value, which our test recipe counts as a
+// failure.
+if(mm(10) == 1)
+{
+    sphere(1);
+}
+else
+{
+    // Nothing
+}

--- a/test/units.scad/override_mils.scad
+++ b/test/units.scad/override_mils.scad
@@ -1,0 +1,19 @@
+
+// Test user-specified override of MCAD's base unit.
+//
+// We give mils a special test just to make sure we got the correction factors
+// right.
+
+include <../../units.scad>
+
+// Override so that the base unit is mils
+MCAD_BASE_UNIT = MCAD_BASE_UNIT_MIL;
+
+if(mil(100) == 100)
+{
+    sphere(1);
+}
+else
+{
+    // Nothing
+}

--- a/test/units.scad/rules.mk
+++ b/test/units.scad/rules.mk
@@ -1,0 +1,32 @@
+
+# Push the current directory onto the directory stack.
+sp             := $(sp).x
+dirstack_$(sp) := $(d)
+d              := $(dir)
+
+# Can the user switch the base units to centimeters?
+#
+# The line "$(d)/test_overrides.test: D := $(d)" is needed because the recipe is
+# actually invoked from the top-level MCAD directory, rather than this
+# directory.  Thus, using $(d) in the recipe results in an empty string.  The
+# target-specific assignment D := $(d) "freezes" the value of $(d) at the time
+# of rule definition, when it has the proper value.
+#
+# $(D) isn't actually used in this recipe, but I left it in because the fact
+# that $(d) isn't available is quite surprising at first.
+.PHONY: $(d)/override_cm.test
+TESTS := $(TESTS) $(d)/override_cm.test
+$(d)/override_cm.test: D := $(d)
+$(d)/override_cm.test: $(d)/override_cm.scad
+	@if ! $(OSCAD_TEST) -o $<.stl $< ; then echo "Test failed: "$< ; fi
+	@rm -f $<.stl
+
+.PHONY: $(d)/override_mils.test
+TESTS := $(TESTS) $(d)/override_mils.test
+$(d)/override_mils.test: $(d)/override_mils.scad
+	@if ! $(OSCAD_TEST) -o $<.stl $< ; then echo "Test failed: "$< ; fi
+	@rm -f $<.stl
+
+# Pop the directory stack.
+d  := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/units.scad
+++ b/units.scad
@@ -5,25 +5,93 @@
  * Dual licenced under Creative Commons Attribution-Share Alike 3.0 and LGPL2 or later
  */
 
+//
+// Internally, OpenSCAD uses arbitrary units, and the mapping from OpenSCAD
+// units to real units is determined by the output pipeline.  No amount of code
+// we write is going to change that.
+//
+// However, when building a design against external objects, it is useful to
+// ensure that relative sizing is correct.  units.scad contains functions and
+// constants for interoperation between measurement systems.
+//
 
-mm = 1;
-cm = 10 * mm;
-dm = 100 * mm;
-m = 1000 * mm;
+//
+// Different choices for MCAD_BASE_UNIT.
+//
+MCAD_BASE_UNIT_MM = 1;
+MCAD_BASE_UNIT_CM = 1 / 10;
+MCAD_BASE_UNIT_DM = 1 / 100;
+MCAD_BASE_UNIT_M  = 1 / 1000;
+MCAD_BASE_UNIT_INCH = 1 / 25.4;
+MCAD_BASE_UNIT_MIL  = 1000 * MCAD_BASE_UNIT_INCH;
 
-inch = 25.4 * mm;
+//
+// By default, we assume that we are working in millimeters.  However, users may
+// override this choice by assigning MCAD_BASE_UNIT to the appropriate
+// scaling factor
+//
+MCAD_BASE_UNIT = MCAD_BASE_UNIT_MM;
 
+//
+// Scale functions.
+//
+// Functions that map from a given scale to OpenSCAD's internal scale.  These
+// should be the main means of expression units on quantities.
+//
+// Internally, they boil the given quantity down to its equivalent in
+// millimeters, then use MCAD_BASE_UNIT to convert to OpenSCAD internal units.
+//
+// Parameters:
+//
+//  q: The quantity to associate with the named unit.
+//
+// Examples:
+//
+//   mm(12) + mil(100)  // 12 millimeters and 100 mils.
+//
+
+function mm(q) = MCAD_BASE_UNIT * q;
+
+function cm(q) = mm(10 * q);
+function dm(q) = mm(100 * q);
+function  m(q) = mm(1000 * q);
+
+function inch(q) =   mm(25.4 * q);
+function  mil(q) = inch(q / 1000);
+function foot(q) = inch(12 * q);
+function yard(q) = inch(36 * q);
+
+//
+// Unit constants (deprecated).
+//
+// Multiplicative constants used to scale between the given units and OpenSCAD
+// internal units.  Consider using the equivalent scale functions.
+//
+
+mm = mm(1);
+cm = mm(10);
+dm = mm(100);
+ m = mm(1000);
+
+inch = inch(1);
+
+M3 = mm(3);
+M4 = mm(4);
+M5 = mm(5);
+M6 = mm(6);
+M8 = mm(8);
+
+//
+// MCAD's internal epsilon setting.
+//
+// Used by the MCAD library whenever a small distance is needed to overlap
+// shapes for boolean cutting, etc.  The user may override it.
+//
+MCAD_EPSILON = mm(0.01);
+
+//
+// Unit vectors.
+//
 X = [1, 0, 0];
 Y = [0, 1, 0];
 Z = [0, 0, 1];
-
-M3 = 3*mm;
-M4 = 4*mm;
-M5 = 5*mm;
-M6 = 6*mm;
-M8 = 8*mm;
-
-
-// When a small distance is needed to overlap shapes for boolean cutting, etc.
-epsilon = 0.01*mm;
-

--- a/utilities.scad
+++ b/utilities.scad
@@ -37,7 +37,7 @@ ExtendedCap =0.5;
 CutCap =-0.5;
 
 
-module fromTo(from=[0,0,0], to=[1*m,0,0], size=[1*cm, 1*cm], align=[CENTER, CENTER], material=[0.5, 0.5, 0.5], name="", endExtras=[0,0], endCaps=[FlatCap, FlatCap], rotation=[0,0,0], printString=true) {
+module fromTo(from=[0,0,0], to=[m(1),0,0], size=[cm(1), cm(1)], align=[CENTER, CENTER], material=[0.5, 0.5, 0.5], name="", endExtras=[0,0], endCaps=[FlatCap, FlatCap], rotation=[0,0,0], printString=true) {
 
   angle = angleBetweenTwoPoints(from, to);
   length = distance(from, to) + endCaps[0]*size[0] + endCaps[1]*size[0] + endExtras[0] + endExtras[1];


### PR DESCRIPTION
Previously, MCAD libraries that dealt with absolutely-sized
artifacts (for example, nuts_and_bolts.scad) either implicitly worked in
millimeters or used a set of multiplicative constants defined in
units.scad (and one constant in constants.scad).

This change introduces a set of scaled functions in units.scad that help
creating objects that are specified in mixed dimensions:

```
    mm(q): millimeters
    cm(q): centimeters
    dm(q):  decimeters
     m(q):      meters
  inch(q):      inches
   mil(q):        mils (0.001 inch)
```

These functions convert from the indicated quantity to OpenSCAD's
internal units.  By default, they are set up so that

```
1 /*OpenSCAD unit*/ == mm(1),
```

but, this can be switched by setting the variable MCAD_BASE_UNIT before
including units.scad.  MCAD_BASE_UNIT is a multiplicative scale factor
that determines the correspondence between MCAD millimeters and OpenSCAD
units.  For example:

```
// a.scad
include <MCAD/units.scad>
echo(cm(1)); // Outputs 10

// b.scad
include <MCAD/units.scad>
MCAD_BASE_UNIT = MCAD_BASE_UNIT_CM;
echo(cm(1)); // Outputs 1
```

Every place in MCAD that was previously using the scale constants from
units.scad and constants.scad has been converted to use the new scale
functions, including the definition of MCAD_EPSILON (now 0.01 mm).

The scale constants have been kept for backwards-compatibility, but are
now defined in terms of the scale functions.

A small suite of tests has been added in the test/ subdirectory of the
project root.  The test suite can be invoked using 'make test' from the
top project directory.

If you want to omit the tests or translate them into the python testing
framework, that's fine.
