### PR TITLE
Added optional "center" param to triangle() and a_triangle() modules

### DIFF
--- a/triangles.scad
+++ b/triangles.scad
@@ -11,14 +11,16 @@
 /**
  * Standard right-angled triangle
  *
- * @param number o_len Lenght of the opposite side
- * @param number a_len Lenght of the adjacent side
- * @param number depth How wide/deep the triangle is in the 3rd dimension
+ * @param number  o_len  Length of the opposite side
+ * @param number  a_len  Length of the adjacent side
+ * @param number  depth  How wide/deep the triangle is in the 3rd dimension
+ * @param boolean center Whether to center the triangle on the origin
  * @todo a better way ?
  */
-module triangle(o_len, a_len, depth)
+module triangle(o_len, a_len, depth, center=false)
 {
-    linear_extrude(height=depth)
+    centroid = center ? [-a_len/3, -o_len/3, -depth/2] : [0, 0, 0];
+    translate(centroid) linear_extrude(height=depth)
     {
         polygon(points=[[0,0],[a_len,0],[0,o_len]], paths=[[0,1,2]]);
     }
@@ -27,16 +29,14 @@ module triangle(o_len, a_len, depth)
 /**
  * Standard right-angled triangle (tangent version)
  *
- * @param number angle of adjacent to hypotenuse (ie tangent)
- * @param number a_len Lenght of the adjacent side
- * @param number depth How wide/deep the triangle is in the 3rd dimension
+ * @param number  tan_angle Angle of adjacent to hypotenuse (ie tangent)
+ * @param number  a_len     Length of the adjacent side
+ * @param number  depth     How wide/deep the triangle is in the 3rd dimension
+ * @param boolean center    Whether to center the triangle on the origin
  */
-module a_triangle(tan_angle, a_len, depth)
+module a_triangle(tan_angle, a_len, depth, center=false)
 {
-    linear_extrude(height=depth)
-    {
-        polygon(points=[[0,0],[a_len,0],[0,tan(tan_angle) * a_len]], paths=[[0,1,2]]);
-    }
+    triangle(tan(tan_angle) * a_len, a_len, depth, center);
 }
 
 // Tests:


### PR DESCRIPTION
For shapes, being able to center them is very useful for quickly add holes in the centers, etc. I wanted to add this ability to some of the basic shapes that are offered in the MCAD library. This pull request starts with the triangle.