### PR TITLE
regular_shapes: Extend hexagon module

### DIFF
--- a/regular_shapes.scad
+++ b/regular_shapes.scad
@@ -41,9 +41,12 @@ module pentagon(radius)
   reg_polygon(5,radius);
 }
 
-module hexagon(radius)
+module hexagon(radius, diameter, across_flats)
 {
-  reg_polygon(6,radius);
+  r = radius;
+  r = diameter ? diameter/2 : radius;
+  r = across_flats ? across_flats/2/cos(30) : radius;
+  reg_polygon(6,r);
 }
 
 module heptagon(radius)
@@ -154,9 +157,11 @@ module pentagon_tube(height,radius,wall)
  tubify(radius,wall) pentagon_prism(height,radius);
 }
 
-module hexagon_prism(height,radius)
+module hexagon_prism(height, radius, across_flats)
 {
-  linear_extrude(height=height) hexagon(radius);
+  r = radius;
+  r = across_flats ? across_flats/2/cos(30) : radius;
+  linear_extrude(height=height) hexagon(r);
 }
 
 module hexagon_tube(height,radius,wall)

--- a/regular_shapes.scad
+++ b/regular_shapes.scad
@@ -43,9 +43,7 @@ module pentagon(radius)
 
 module hexagon(radius, diameter, across_flats)
 {
-  r = radius;
-  r = diameter ? diameter/2 : radius;
-  r = across_flats ? across_flats/2/cos(30) : radius;
+  r = across_flats ? across_flats/2/cos(30) : diameter ? diameter/2 : radius;
   reg_polygon(6,r);
 }
 
@@ -159,9 +157,8 @@ module pentagon_tube(height,radius,wall)
 
 module hexagon_prism(height, radius, across_flats)
 {
-  r = radius;
-  r = across_flats ? across_flats/2/cos(30) : radius;
-  linear_extrude(height=height) hexagon(r);
+  linear_extrude(height=height)
+    hexagon(radius=radius, across_flats=across_flats);
 }
 
 module hexagon_tube(height,radius,wall)


### PR DESCRIPTION
Allow the hexagon to be defined by the distance between sides,
which is also the diameter of the inscribed circle.