### PR TITLE
regular_shapes: Avoid the circle trick

### DIFF
--- a/regular_shapes.scad
+++ b/regular_shapes.scad
@@ -33,7 +33,11 @@ module reg_polygon(sides,radius)
   if(sides<2) square([radius,0]);
   if(sides==3) triangle(radius);
   if(sides==4) square([dia(radius),dia(radius)],center=true);
-  if(sides>4) circle(r=radius,$fn=sides);
+  if(sides>4) {
+    angles=[ for (i = [0:sides-1]) i*(360/sides) ];
+    coords=[ for (th=angles) [radius*cos(th), radius*sin(th)] ];
+    polygon(coords);
+  }
 }
 
 module pentagon(radius)


### PR DESCRIPTION
As is stated in the very own manual of OpenSCAD [1], generating polygons
using the circle function is a trick that should be avoided.

 [1] https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/2D_Primitives#regular_polygon