### PR TITLE
circle does not have a center parameter

### DIFF
--- a/teardrop.scad
+++ b/teardrop.scad
@@ -23,7 +23,7 @@ This script generates a teardrop shape at the appropriate angle to prevent overh
 module teardrop(radius, length, angle) {
 	rotate([0, angle, 0]) union() {
 		linear_extrude(height = length, center = true, convexity = radius, twist = 0)
-			circle(r = radius, center = true, $fn = 30);
+			circle(r = radius, $fn = 30);
 		linear_extrude(height = length, center = true, convexity = radius, twist = 0)
 			projection(cut = false) rotate([0, -angle, 0]) translate([0, 0, radius * sin(45) * 1.5]) cylinder(h = radius * sin(45), r1 = radius * sin(45), r2 = 0, center = true, $fn = 30);
 	}


### PR DESCRIPTION
I am developing a check for unspecified parameters in module and function calls.

Setting center=true on a circle is incorrect:

https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#circle

https://github.com/openscad/openscad/blob/5c139edeb25bfd5c9804b3896f28c12c005091e4/src/primitives.cc#L271-L277