### PR TITLE
fixed typo in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 OpenSCAD MCAD Library [![](http://stillmaintained.com/elmom/MCAD.png)](http://stillmaintained.com/elmom/MCAD)
 =====================
 
-This library contains components commonly used in designing and moching up
+This library contains components commonly used in designing and mocking up
 mechanical designs. It is currently unfinished and you can expect some API
 changes, however many things are already working.
 


### PR DESCRIPTION
I think it means mocking up as in [mock up](https://en.wikipedia.org/wiki/Mockup)