### PR TITLE
Minor changes to nutsnbolts

### DIFF
--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -157,7 +157,19 @@ METRIC_BOLT_CAP_DIAMETERS = [
 	-1,
 	-1,
 	-1,
-	36 // m24
+	36, // m24
+	-1,
+	-1,
+	-1,
+	-1,
+	-1,
+	45, //m30
+	-1,
+	-1,
+	-1,
+	-1,
+	-1,
+	54 // m36
 ];
 
 function mcad_metric_nut_ac_width (size) = METRIC_NUT_AC_WIDTHS[size];

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -1,4 +1,5 @@
 use <MCAD/array/along_curve.scad>
+use <MCAD/array/rectangular.scad>
 include <MCAD/units/metric.scad>
 // Copyright 2010 D1plo1d
 // Copyright 2017 Chow Loong Jin <hyperair@debian.org>

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -199,7 +199,7 @@ module mcad_bolt_hole (size, length, cap_extra_length, tolerance = +0.0001,
 
 	if (proj == -1)
 	{
-		translate([0, 0, -cap_height - cap_extra_length])
+		translate([0, 0, -cap_height - cap_extra_length + epsilon])
 			cylinder(r = cap_radius, h = cap_height + cap_extra_length);
 		cylinder(r = radius, h = length);
 	}


### PR DESCRIPTION
Tweaks to nuts_and_bolts.scad:

- Use array/rectangular.scad to be able to use mcad_linear_multiply() as it was previously moved from along_surve.scad
- Populates METRIC_BOLT_CAP_DIAMETERS up thru M36 since METRIC_NUT_AD_WIDTHS and METRIC_NUT_THICKNESS has thru M36 already
- Adds an epsilon to the translate in mcad_bolt_hole to fix clipping
