### PR TITLE
Nutsandbolts rework

### DIFF
--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -15,8 +15,7 @@ module mcad_test_nuts_and_bolts_1 ()
 	translate ([0, 15])
 		mcad_nut_hole (3, proj = -1);
 
-	mcad_bolt_hole (3, length = 30,tolerance =10, proj = -1);
-
+	mcad_bolt_hole (3, length = 30, tolerance = 10, proj = -1);
 }
 //mcad_test_nuts_and_bolts_1 ();
 
@@ -42,12 +41,8 @@ module mcad_test_nuts_and_bolts_3 ()
 {
 	$fn = 360;
 
-	mcad_bolt_hole_with_nut (
-		size = 3,
-		length = 10
-	);
+	mcad_bolt_hole_with_nut (size = 3, length = 10);
 }
-
 //mcad_test_nuts_and_bolts_3 ();
 
 // ISO 4032 nut width across flats:
@@ -148,27 +143,29 @@ module mcad_bolt_hole (size, length,
                        tolerance = +0.0001,
                        proj = -1)
 {
+	//look up nut dimensions from screw size
 	radius = mcad_metric_bolt_major_diameter (size) / 2 + tolerance;
-
 	cap_height = mcad_metric_bolt_cap_height (size) + tolerance;
 	cap_radius = mcad_metric_bolt_cap_diameter (size) / 2 + tolerance;
 
 	if (proj == -1)
 	{
-		translate([0, 0, -cap_height - cap_extra_length + epsilon])
-			cylinder(r = cap_radius, h = cap_height + cap_extra_length);
-		cylinder(r = radius, h = length);
+		translate ([0, 0, -cap_height - cap_extra_length + epsilon])
+			cylinder (r = cap_radius, h = cap_height + cap_extra_length);
+		cylinder (r = radius, h = length);
 	}
+
 	if (proj == 1)
 	{
-		circle(r = radius);
+		circle (r = radius);
 	}
+
 	if (proj == 2)
 	{
-		translate([-cap_radius, - cap_height])
-			square([cap_radius * 2, cap_height]);
-		translate([-radius, 0])
-			square([radius * 2, length]);
+		translate ([-cap_radius, - cap_height])
+			square ([cap_radius * 2, cap_height]);
+		translate ([-radius, 0])
+			square ([radius * 2, length]);
 	}
 }
 
@@ -181,7 +178,8 @@ module mcad_bolt_hole (size, length,
  * @param align_with Alignment of whole set (above_head, below_head, center,
  *                                           below_nut, above_nut)
  */
-module mcad_bolt_hole_with_nut (size, length, nut_projection = "axial",
+module mcad_bolt_hole_with_nut (size, length,
+                                nut_projection = "axial",
                                 align_with = "above_head",
                                 screw_extra_length = 9999,
                                 head_extra_length = 9999,

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -201,7 +201,9 @@ module mcad_nut_hole (size, tolerance = +0.0001, proj = -1)
 	}
 }
 
-module mcad_bolt_hole (size, length, cap_extra_length, tolerance = +0.0001,
+module mcad_bolt_hole (size, length,
+                       cap_extra_length = 0,
+                       tolerance = +0.0001,
                        proj = -1)
 {
 	radius = mcad_metric_bolt_major_diameter (size) / 2 + tolerance;

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -45,6 +45,27 @@ module mcad_test_nuts_and_bolts_3 ()
 }
 //mcad_test_nuts_and_bolts_3 ();
 
+// DEPRECATED dimensions across corners: backcompat only
+METRIC_NUT_AC_WIDTH =
+[
+	[1.6,  3.41],
+	[  2,  4.32],
+	[2.5,  5.45],
+	[  3,  6.40],
+	[  4,  8.10],
+	[  5,  9.20],
+	[  6, 11.50],
+	[  8, 15.00],
+	[ 10, 19.60],
+	[ 12, 22.10],
+	[ 16, 27.70],
+	[ 20, 34.60],
+	[ 24, 41.60],
+	[ 30, 53.10],
+	[ 36, 63.50]
+];
+
+
 // ISO 4032 nut width across flats:
 // http://www.fasteners.eu/standards/ISO/4032/
 METRIC_NUT_AF_WIDTH =
@@ -108,6 +129,10 @@ METRIC_BOLT_CAP_DIAMETER =
 	[36, 54.0]
 ];
 
+// DEPRECATED: backcompat only
+function mcad_metric_nut_ac_width (size) =
+    lookup (size, METRIC_NUT_AC_WIDTH);
+
 function mcad_metric_nut_af_width (size) =
     lookup (size, METRIC_NUT_AF_WIDTH);
 function mcad_metric_nut_thickness (size) =
@@ -119,22 +144,37 @@ function mcad_metric_bolt_cap_height (size) = size;
 
 module mcad_nut_hole (size, tolerance = +0.0001, proj = -1)
 {
-	//takes a metric screw/nut size and looksup nut dimensions
-	radius = mcad_metric_nut_ac_width (size) / 2 + tolerance;
+	//look up nut dimensions from screw size
+	width = mcad_metric_nut_af_width (size) + tolerance;
 	height = mcad_metric_nut_thickness (size) + tolerance;
 
-	if (proj == -1) {
-		cylinder (r = radius, h = height, $fn = 6, center = [0, 0]);
-	}
+	//DEPRECATED: backcompat only
+	radius = (mcad_metric_nut_ac_width (size) / 2) + tolerance;
 
-	else if (proj == 1) {
-		circle(r = radius, $fn = 6);
-	}
-
-	else if (proj == 2)
+	if (proj == -1)
 	{
-		translate ([-radius/2, 0])
+		linear_extrude (height = height) {
+			hexagon (across_flats = width);
+		}
+	}
+
+	if (proj == 1)
+	{
+		hexagon (across_flats = width);
+	}
+
+	if (proj == 2)
+	{
+		echo ("<font color = 'red'>
+              DEPRECATED: proj = 2 uses dimensions across corners and nuts will not trap.
+              Please use proj = 3 instead to use dimensions across flats instead</font>");
+		translate ([-radius, 0])
 			square ([radius*2, height]);
+	}
+	if (proj == 3)
+	{
+		translate ([-width/2, 0])
+			square ([width, height]);
 	}
 }
 

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -23,15 +23,15 @@ module mcad_test_nuts_and_bolts_2 ()
 {
 	$fn = 360;
 
-	difference(){
-		cube(size = [10, 20, 10], center = true);
-		union(){
-			translate ([0, 15])
-				mcad_nut_hole (3, proj = 2);
-
+	difference () {
+		cube (size = [10, 40, 10], center = true);
+		union () {
 			linear_extrude (height = 20, center = true, convexity = 10,
-			                twist = 0)
-			mcad_bolt_hole (3, length = 30, proj = 2);
+			                twist = 0) {
+				mcad_nut_hole (3, proj = 2);
+				translate ([0, -15])
+					mcad_bolt_hole (3, length = 30, proj = 2);
+			}
 		}
 	}
 }

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -1,5 +1,6 @@
 use <MCAD/array/along_curve.scad>
 use <MCAD/array/rectangular.scad>
+use <MCAD/shapes/2Dshapes.scad>
 include <MCAD/units/metric.scad>
 // Copyright 2010 D1plo1d
 // Copyright 2017 Chow Loong Jin <hyperair@debian.org>

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -50,24 +50,25 @@ module mcad_test_nuts_and_bolts_3 ()
 
 //mcad_test_nuts_and_bolts_3 ();
 
-//Based on: http://www.roymech.co.uk/Useful_Tables/Screws/Hex_Screws.htm
-METRIC_NUT_AC_WIDTH =
+// ISO 4032 nut width across flats:
+// http://www.fasteners.eu/standards/ISO/4032/
+METRIC_NUT_AF_WIDTH =
 [
-	[1.6,  3.41],
-	[  2,  4.32],
-	[2.5,  5.45],
-	[  3,  6.40],
-	[  4,  8.10],
-	[  5,  9.20],
-	[  6, 11.50],
-	[  8, 15.00],
-	[ 10, 19.60],
-	[ 12, 22.10],
-	[ 16, 27.70],
-	[ 20, 34.60],
-	[ 24, 41.60],
-	[ 30, 53.10],
-	[ 36, 63.50]
+	[1.6,  3.20],
+	[  2,  4.00],
+	[2.5,  5.00],
+	[  3,  5.50],
+	[  4,  7.00],
+	[  5,  8.00],
+	[  6, 10.00],
+	[  8, 13.00],
+	[ 10, 16.00],
+	[ 12, 18.00],
+	[ 16, 24.00],
+	[ 20, 30.00],
+	[ 24, 36.00],
+	[ 30, 46.00],
+	[ 36, 55.00]
 ];
 
 // ISO 4032 nut thickness:
@@ -112,8 +113,8 @@ METRIC_BOLT_CAP_DIAMETER =
 	[36, 54.0]
 ];
 
-function mcad_metric_nut_ac_width (size) =
-    lookup (size, METRIC_NUT_AC_WIDTH);
+function mcad_metric_nut_af_width (size) =
+    lookup (size, METRIC_NUT_AF_WIDTH);
 function mcad_metric_nut_thickness (size) =
     lookup (size, METRIC_NUT_THICKNESS);
 function mcad_metric_bolt_cap_diameter (size) =

--- a/fasteners/nuts_and_bolts.scad
+++ b/fasteners/nuts_and_bolts.scad
@@ -51,135 +51,75 @@ module mcad_test_nuts_and_bolts_3 ()
 //mcad_test_nuts_and_bolts_3 ();
 
 //Based on: http://www.roymech.co.uk/Useful_Tables/Screws/Hex_Screws.htm
-METRIC_NUT_AC_WIDTHS =
+METRIC_NUT_AC_WIDTH =
 [
-	-1, //0 index is not used but reduces computation
-	-1,
-	4.32, //m2
-	6.40,//m3
-	8.10,//m4
-	9.20,//m5
-	11.50,//m6
-	-1,
-	15.00,//m8
-	-1,
-	19.60,//m10
-	-1,
-	22.10,//m12
-	-1,
-	-1,
-	-1,
-	27.70,//m16
-	-1,
-	-1,
-	-1,
-	34.60,//m20
-	-1,
-	-1,
-	-1,
-	41.60,//m24
-	-1,
-	-1,
-	-1,
-	-1,
-	-1,
-	53.1,//m30
-	-1,
-	-1,
-	-1,
-	-1,
-	-1,
-	63.5//m36
+	[1.6,  3.41],
+	[  2,  4.32],
+	[2.5,  5.45],
+	[  3,  6.40],
+	[  4,  8.10],
+	[  5,  9.20],
+	[  6, 11.50],
+	[  8, 15.00],
+	[ 10, 19.60],
+	[ 12, 22.10],
+	[ 16, 27.70],
+	[ 20, 34.60],
+	[ 24, 41.60],
+	[ 30, 53.10],
+	[ 36, 63.50]
 ];
 
+// ISO 4032 nut thickness:
+// http://www.fasteners.eu/standards/ISO/4032/
 METRIC_NUT_THICKNESS =
 [
-	-1, //0 index is not used but reduces computation
-	-1,
-	1.6,//m2
-	2.40,//m3
-	3.20,//m4
-	4.00,//m5
-	5.00,//m6
-	-1,
-	6.50,//m8
-	-1,
-	8.00,//m10
-	-1,
-	10.00,//m12
-	-1,
-	-1,
-	-1,
-	13.00,//m16
-	-1,
-	-1,
-	-1,
-	16.00//m20
-	-1,
-	-1,
-	-1,
-	19.00,//m24
-	-1,
-	-1,
-	-1,
-	-1,
-	-1,
-	24.00,//m30
-	-1,
-	-1,
-	-1,
-	-1,
-	-1,
-	29.00//m36
+	[1.6, 1.3],
+	[  2, 1.6],
+	[2.5, 2.0],
+	[ 3,  2.4],
+	[ 4,  3.2],
+	[ 5,  4.7],
+	[ 6,  5.2],
+	[ 8,  6.8],
+	[10,  8.4],
+	[12, 10.8],
+	[16, 14.8],
+	[20, 18.0],
+	[24, 21.5],
+	[30, 25.6],
+	[36, 31.0]
 ];
 
-METRIC_BOLT_CAP_DIAMETERS = [
-	-1,
-	-1,
-	3.8, // m2
-	5.5, // m3
-	7, // m4
-	8.5, // m5
-	10, // m6
-	-1,
-	13, // m8
-	-1,
-	16, // m10
-	-1,
-	18, // m12
-	-1,
-	-1,
-	-1,
-	24, // m16
-	-1,
-	-1,
-	-1,
-	30, // m20
-	-1,
-	-1,
-	-1,
-	36, // m24
-	-1,
-	-1,
-	-1,
-	-1,
-	-1,
-	45, //m30
-	-1,
-	-1,
-	-1,
-	-1,
-	-1,
-	54 // m36
+// ISO 4762 cap screw diameters:
+// http://www.fasteners.eu/standards/ISO/4762/
+METRIC_BOLT_CAP_DIAMETER =
+[
+	[1.6, 3.0],
+	[  2, 3.8],
+	[2.5, 4.5],
+	[ 3,  5.5],
+	[ 4,  7.0],
+	[ 5,  8.5],
+	[ 6, 10.0],
+	[ 8, 13.0],
+	[10, 16.0],
+	[12, 18.0],
+	[16, 24.0],
+	[20, 30.0],
+	[24, 36.0],
+	[30, 45.0],
+	[36, 54.0]
 ];
 
-function mcad_metric_nut_ac_width (size) = METRIC_NUT_AC_WIDTHS[size];
-function mcad_metric_nut_thickness (size) = METRIC_NUT_THICKNESS[size];
+function mcad_metric_nut_ac_width (size) =
+    lookup (size, METRIC_NUT_AC_WIDTH);
+function mcad_metric_nut_thickness (size) =
+    lookup (size, METRIC_NUT_THICKNESS);
+function mcad_metric_bolt_cap_diameter (size) =
+    lookup (size, METRIC_BOLT_CAP_DIAMETER);
 function mcad_metric_bolt_major_diameter (size) = size;
 function mcad_metric_bolt_cap_height (size) = size;
-function mcad_metric_bolt_cap_diameter (size) = (
-	METRIC_BOLT_CAP_DIAMETERS[size]
-);
 
 module mcad_nut_hole (size, tolerance = +0.0001, proj = -1)
 {


### PR DESCRIPTION
This PR contains a collection of work on nuts_and_bolts:

- update the dimension arrays to use ISO dimensions for nuts and cap screw heads
I also chose to use across flat dimensions for nuts and use hexagons calculated from that dimension, instead of the existing _circle ($fn = 6)_ so that nut traps are more functional.

- default cap_extra_length to 0 in mcad_bolt_hole to avoid an undef warning

- extend the cube in mcad_test_nuts_and_bolts_2 to show the entirety of the generated nut and bolt boles, as well as include the linear extrude for the nut hole

- tidy up whitespace across the file