### PR TITLE
Add flat Nema 17HS08, fix Aluminium color, Extract holes

### DIFF
--- a/stepper.scad
+++ b/stepper.scad
@@ -44,6 +44,7 @@ NemaBackAxleLength = 15;
 NemaAxleFlatDepth = 16;
 NemaAxleFlatLengthFront = 17;
 NemaAxleFlatLengthBack = 18;
+NemaFlat = 19;
 
 NemaA = 1;
 NemaB = 2;
@@ -122,6 +123,7 @@ Nema14 = [
 
 Nema17 = [
                 [NemaModel, 17],
+                [NemaFlat, 20.7*mm],
                 [NemaLengthShort, 33*mm],
                 [NemaLengthMedium, 39*mm],
                 [NemaLengthLong, 47*mm],
@@ -225,9 +227,10 @@ module motor(model=Nema23, size=NemaMedium, dualAxis=false, pos=[0,0,0], orienta
   axleFlatLengthFront = lookup(NemaAxleFlatLengthFront, model);
   axleFlatLengthBack = lookup(NemaAxleFlatLengthBack, model);
 
-  color(stepperBlack){
+  {
     translate(pos) rotate(orientation) {
       translate([-mid, -mid, 0]) 
+        color(stepperBlack)
         difference() {          
           cube(size=[side, side, length + extrSize]);
  

--- a/stepper.scad
+++ b/stepper.scad
@@ -10,7 +10,7 @@ include <materials.scad>
 
 
 // Demo, uncomment to show:
-//nema_demo();
+// nema_demo();
 
 module nema_demo(){
     for (size = [NemaShort, NemaMedium, NemaLong]) {  
@@ -21,6 +21,9 @@ module nema_demo(){
       translate([300,size*100,0])  motor(Nema11, size, dualAxis=true);
       translate([400,size*100,0])  motor(Nema08, size, dualAxis=true);
     }
+
+	// Nema 17HS08
+    translate([100,400,0])  motor(Nema17, NemaFlat, dualAxis=false);
 }
 
 
@@ -201,37 +204,24 @@ module motor(model=Nema23, size=NemaMedium, dualAxis=false, pos=[0,0,0], orienta
   echo(str("  Motor: Nema",lookup(NemaModel, model),", length= ",length,"mm, dual axis=",dualAxis));
 
   stepperBlack    = BlackPaint;
-  stepperAluminum = Aluminum;
 
   side = lookup(NemaSideSize, model);
 
   cutR = lookup(NemaMountingHoleCutoutRadius, model);
   lip = lookup(NemaMountingHoleLip, model);
-  holeDepth = lookup(NemaMountingHoleDepth, model);
-
-  axleLengthFront = lookup(NemaFrontAxleLength, model);
-  axleLengthBack = lookup(NemaBackAxleLength, model);
-  axleRadius = lookup(NemaAxleDiameter, model) * 0.5;
 
   extrSize = lookup(NemaRoundExtrusionHeight, model);
   extrRad = lookup(NemaRoundExtrusionDiameter, model) * 0.5;
-
-  holeDist = lookup(NemaDistanceBetweenMountingHoles, model) * 0.5;
-  holeRadius = lookup(NemaMountingHoleDiameter, model) * 0.5;
 
   mid = side / 2;
 
   roundR = lookup(NemaEdgeRoundingRadius, model);
 
-  axleFlatDepth = lookup(NemaAxleFlatDepth, model);
-  axleFlatLengthFront = lookup(NemaAxleFlatLengthFront, model);
-  axleFlatLengthBack = lookup(NemaAxleFlatLengthBack, model);
-
   {
     translate(pos) rotate(orientation) {
       translate([-mid, -mid, 0]) 
         color(stepperBlack)
-        difference() {          
+        difference() {
           cube(size=[side, side, length + extrSize]);
  
           // Corner cutouts
@@ -261,52 +251,78 @@ module motor(model=Nema23, size=NemaMedium, dualAxis=false, pos=[0,0,0], orienta
           }
 
           // Bolt holes
-          color(stepperAluminum, $fs=holeRadius/8) {
-            translate([mid+holeDist,mid+holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
-            translate([mid-holeDist,mid+holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
-            translate([mid+holeDist,mid-holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
-            translate([mid-holeDist,mid-holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
+          translate([mid, mid, 0])
+            stepper_bolt_holes(model);
 
-          } 
+		  translate([-1*mm, -1*mm, -1*mm])
+			cube(size=[side+2*mm, side+2*mm, extrSize + 1*mm]);
+      }
 
-          // Grinded flat
-          color(stepperAluminum) {
-            difference() {
-              translate([-1*mm, -1*mm, -1*mm])
-                cube(size=[side+2*mm, side+2*mm, extrSize + 1*mm]);
-              translate([side/2, side/2, -1*mm])
-                cylinder(h=extrSize + 1*mm, r=extrRad);
-            }
-          }
-
-        }
+      // Grinded flat
+      color(Aluminum)
+	    cylinder(h=extrSize+1, r=extrRad);
 
       // Axle
-      translate([0, 0, extrSize-axleLengthFront]) color(stepperAluminum) 
-        difference() {
-                     
-          cylinder(h=axleLengthFront + 1*mm , r=axleRadius, $fs=axleRadius/10);
+      stepper_front_axle(model);
 
-          // Flat
-          if (axleFlatDepth > 0)
-            translate([axleRadius - axleFlatDepth,-5*mm,-extrSize*mm -(axleLengthFront-axleFlatLengthFront)] ) cube(size=[5*mm, 10*mm, axleLengthFront]);
-        }
-
-        if (dualAxis) {
-          translate([0, 0, length+extrSize]) color(stepperAluminum) 
-            difference() {
-                     
-              cylinder(h=axleLengthBack + 0*mm, r=axleRadius, $fs=axleRadius/10);
-
-              // Flat
-              if (axleFlatDepth > 0)
-                translate([axleRadius - axleFlatDepth,-5*mm,(axleLengthBack-axleFlatLengthBack)]) cube(size=[5*mm, 10*mm, axleLengthBack]);
-          }
-
-        }
-
+      if (dualAxis) {
+        stepper_back_axle(model, size);
+      }
     }
   }
+}
+
+module stepper_bolt_holes(model) {
+  holeDist = lookup(NemaDistanceBetweenMountingHoles, model) * 0.5;
+  holeRadius = lookup(NemaMountingHoleDiameter, model) * 0.5;
+  holeDepth = lookup(NemaMountingHoleDepth, model);
+  extrSize = lookup(NemaRoundExtrusionHeight, model);
+
+  color(Aluminum, $fs=holeRadius/8) {
+    translate([+holeDist,+holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
+    translate([-holeDist,+holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
+    translate([+holeDist,-holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
+    translate([-holeDist,-holeDist,-1*mm]) cylinder(h=holeDepth+1*mm+extrSize, r=holeRadius);
+  } 
+}
+
+module stepper_front_axle(model) {
+  extrSize = lookup(NemaRoundExtrusionHeight, model);
+  axleRadius = lookup(NemaAxleDiameter, model) * 0.5;
+  axleFlatDepth = lookup(NemaAxleFlatDepth, model);
+
+  axleLengthFront = lookup(NemaFrontAxleLength, model);
+  axleFlatLengthFront = lookup(NemaAxleFlatLengthFront, model);
+
+  translate([0, 0, extrSize-axleLengthFront]) color(Aluminum)
+    difference() {
+
+      cylinder(h=axleLengthFront + 1*mm , r=axleRadius, $fs=axleRadius/10);
+
+      // Flat
+      if (axleFlatDepth > 0)
+        translate([axleRadius - axleFlatDepth,-5*mm,-extrSize*mm -(axleLengthFront-axleFlatLengthFront)] ) cube(size=[5*mm, 10*mm, axleLengthFront]);
+    }
+}
+
+module stepper_back_axle(model, size = NemaMedium) {
+  extrSize = lookup(NemaRoundExtrusionHeight, model);
+  axleRadius = lookup(NemaAxleDiameter, model) * 0.5;
+  axleFlatDepth = lookup(NemaAxleFlatDepth, model);
+
+  axleFlatLengthBack = lookup(NemaAxleFlatLengthBack, model);
+  axleLengthBack = lookup(NemaBackAxleLength, model);
+  length = lookup(size, model);
+
+  translate([0, 0, length+extrSize]) color(Aluminum)
+    difference() {
+
+      cylinder(h=axleLengthBack + 0*mm, r=axleRadius, $fs=axleRadius/10);
+
+      // Flat
+      if (axleFlatDepth > 0)
+        translate([axleRadius - axleFlatDepth,-5*mm,(axleLengthBack-axleFlatLengthBack)]) cube(size=[5*mm, 10*mm, axleLengthBack]);
+    }
 }
 
 module roundedBox(size, edgeRadius) {


### PR DESCRIPTION
A flat Nema17 motor (height 20.7mm) was added. It did not fit the "Short,Medium,Long" categories, so I added a "NemaFlat" category.

The shaft and grinded flat shape were black, but I think the are silver on most motors.

The mounting holes were refactored out into a module, so they can be easily used to add mounting holes to a custom build plate.

Before 
![stepper_before](https://user-images.githubusercontent.com/6494025/62145617-0f4d4f80-b2f4-11e9-8e3d-b8c029cd7b99.png)

After
![stepper_after](https://user-images.githubusercontent.com/6494025/62145627-14120380-b2f4-11e9-89f5-65c1156c09cd.png)
