### PR TITLE
Use children() instead of child()

### DIFF
--- a/regular_shapes.scad
+++ b/regular_shapes.scad
@@ -142,8 +142,8 @@ module tubify(radius,wall)
 {
   difference()
   {
-    child(0);
-    translate([0, 0, -0.1]) scale([(radius-wall)/radius, (radius-wall)/radius, 2]) child(0);
+    children(0);
+    translate([0, 0, -0.1]) scale([(radius-wall)/radius, (radius-wall)/radius, 2]) children(0);
   }
 }
 


### PR DESCRIPTION
> DEPRECATED: child() will be removed in future releases. Use children() instead.