### PR TITLE
Remove center from circles in tube module

### DIFF
--- a/shapes/3Dshapes.scad
+++ b/shapes/3Dshapes.scad
@@ -23,7 +23,7 @@
 //torus2(r1, r2);
 //oval_torus(inner_radius, thickness=[0, 0]);
 
-//tube(height, radius, wall, center = false);
+//tube(h, r, wall, center = false)
 //tube2(height, ID, OD, center = false);
 //oval_tube(width, height, depth, wall, center = false);
 
@@ -183,10 +183,10 @@ module oval_torus(inner_radius, thickness=[0, 0])
 
 // wall is wall thickness
 module tube(h, r, wall, center = false) {
-  linear_extrude (height=h, center=center)
+  linear_extrude (height = h, center = center)
   difference() {
-    circle(r=r, center=center);
-    circle(r=r-wall, center=center);
+    circle(r=r);
+    circle(r=r-wall);
   }
 }
 


### PR DESCRIPTION
Center is not a parameter used by circle(), and causes warnings when using tube(). This removes the center parameter specified for the two circles in tubes(). Also updated the module signature at the head of the file and generally tidied spacing in tube().