### PR TITLE
More efficient and configurable implementation for roundedBox (roundedCube)

### DIFF
--- a/boxes.scad
+++ b/boxes.scad
@@ -4,40 +4,43 @@
 // Copyright: 2010
 // License: 2-clause BSD License (http://opensource.org/licenses/BSD-2-Clause)
 
-// roundedBox([width, height, depth], float radius, bool sidesonly);
+// 
+// roundedCube([x, y, z], r, sidesonly=true/false, center=true/false);
+// roundedCube(x, r, sidesonly=true/false, center=true/false);
 
 // EXAMPLE USAGE:
-// roundedBox([20, 30, 40], 5, true);
+// roundedCube([20, 30, 40], 5, true, true);
 
-// size is a vector [w, h, d]
+// Only for backwards compatibility with existing scripts, (always centered, radius instead of consistent "r" naming.
 module roundedBox(size, radius, sidesonly)
 {
-  rot = [ [0,0,0], [90,0,90], [90,90,0] ];
-  if (sidesonly) {
-    cube(size - [2*radius,0,0], true);
-    cube(size - [0,2*radius,0], true);
-    for (x = [radius-size[0]/2, -radius+size[0]/2],
-           y = [radius-size[1]/2, -radius+size[1]/2]) {
-      translate([x,y,0]) cylinder(r=radius, h=size[2], center=true);
-    }
-  }
-  else {
-    cube([size[0], size[1]-radius*2, size[2]-radius*2], center=true);
-    cube([size[0]-radius*2, size[1], size[2]-radius*2], center=true);
-    cube([size[0]-radius*2, size[1]-radius*2, size[2]], center=true);
+  echo("WARNING: roundedBox(size, radius, sidesonly) is deprecated, use roundedCube(size, r, sidesonly, center)");
+  roundedCube(size, radius, sidesonly, true);
+}
 
-    for (axis = [0:2]) {
-      for (x = [radius-size[axis]/2, -radius+size[axis]/2],
-             y = [radius-size[(axis+1)%3]/2, -radius+size[(axis+1)%3]/2]) {
-        rotate(rot[axis])
-          translate([x,y,0])
-          cylinder(h=size[(axis+2)%3]-2*radius, r=radius, center=true);
+// New implementation
+module roundedCube(size, r, sidesonly, center) {
+  s = is_list(size) ? size : [size,size,size];
+  translate(center ? -s/2 : [0,0,0]) {
+    if (sidesonly) {
+      hull() {
+        translate([     r,     r]) cylinder(r=r, h=s[2]);
+        translate([     r,s[1]-r]) cylinder(r=r, h=s[2]);
+        translate([s[0]-r,     r]) cylinder(r=r, h=s[2]);
+        translate([s[0]-r,s[1]-r]) cylinder(r=r, h=s[2]);
       }
     }
-    for (x = [radius-size[0]/2, -radius+size[0]/2],
-           y = [radius-size[1]/2, -radius+size[1]/2],
-           z = [radius-size[2]/2, -radius+size[2]/2]) {
-      translate([x,y,z]) sphere(radius);
+    else {
+      hull() {
+        translate([     r,     r,     r]) sphere(r=r);
+        translate([     r,     r,s[2]-r]) sphere(r=r);
+        translate([     r,s[1]-r,     r]) sphere(r=r);
+        translate([     r,s[1]-r,s[2]-r]) sphere(r=r);
+        translate([s[0]-r,     r,     r]) sphere(r=r);
+        translate([s[0]-r,     r,s[2]-r]) sphere(r=r);
+        translate([s[0]-r,s[1]-r,     r]) sphere(r=r);
+        translate([s[0]-r,s[1]-r,s[2]-r]) sphere(r=r);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR changes `roundedBox` to use hull.
Using hull makes it much more efficient to compute, and the geometry (rounded cube corners) is more correct without mismatched seams between spheres/cylinders in the corners/edges of the rounded cube.

I also thought it would make most sense to stick to the parameter conventions used by OpenSCAD native modules: https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#cube so the following changes where made:
1) In addition to `size=[x,y,z]` the new version optionally accepts a single number for size, which applies to all three dimensions.
2) `roundedBox` had no `center` parameter, it was always centered.  The new module now provides the option, and defaults to *not centered*, just as the native `cube` module does.
3) minor change but parameter name `r` is more conventional than `radius` (used by cylinder, sphere etc.) so the new module also uses `r`.

Since the interface for this module would have changed, I thought it would be best to "deprecate" `roundedBox` by echoing a "warning" statement and name the new module `roundedCube` so that old scripts using MCAD can remain backwards compatible.