### PR TITLE
Change tube2 to use linear_extrude

### DIFF
--- a/shapes/3Dshapes.scad
+++ b/shapes/3Dshapes.scad
@@ -191,9 +191,11 @@ module tube(h, r, wall, center = false) {
 }
 
 module tube2(height, ID, OD, center = false) {
-  difference() {
-    cylinder(h=height, r=OD/2, center=center);
-    cylinder(h=height, r=ID/2, center=center);
+  linear_extrude (height = height, center = center) {
+    difference() {
+      circle(r=OD/2);
+      circle(r=ID/2);
+    }
   }
 }
 


### PR DESCRIPTION
Diff of two cylinders caused render artifacts. 
Change tolinear_extrude instead of adding a translate/extra height to the inner cylinder.
Also maybe faster?