### PR TITLE
Cleanup

### DIFF
--- a/array.scad
+++ b/array.scad
@@ -30,7 +30,7 @@ module Cubic_and_Radial_Array_Test()
 //cubic array  of  5*5*5 objects spaced 10*10*10 center relative
  	Cubic_Array(10,10,10,5,5,5,center=true)
 		{
-		sphere(2.5,center=true,$fn=60);
+			sphere(2.5,$fn=60);
 			cylinder(h=10,r=.5,center=true);
 			rotate([90,0,0])
 			cylinder(h=10,r=.5,center=true);
@@ -91,43 +91,22 @@ module Cubic_and_Radial_Array_Test()
 
 
 // main lib modules
-module Cubic_Array(sx,sy,sz,nx,ny,nz,center)
-	{
+module Cubic_Array(sx,sy,sz,nx,ny,nz,center) {
 	if (center==true)
-		{
 		translate([-(((nx+1)*sx)/2),-(((ny+1)*sy)/2),-(((nz+1)*sz)/2)])
-			{
 			for(x=[1:nx])
-				{
 				for(y=[1:ny])
-					{
 					for(z=[1:nz])
-						{
 						translate([x*sx,y*sy,z*sz])
-						for (k = [0:$children-1]) child(k,center=true);;
-						}
-					}
-				}
-			}
-		}
+							children([0:$children-1],center=true);
 	else
-		{
 		translate([0,0,0])
-			{
 			for(x=[1:nx])
-				{
-				for(y=[1:ny])
-					{
+			    for(y=[1:ny])
 					for(z=[1:nz])
-						{
 						translate([x*sx,y*sy,z*sz])
-						for (k = [0:$children-1]) child(k);
-						}
-					}
-				}
-			}
-		}
-	}
+						    children([0:$children-1]);
+}
 
 //
 //Radial_Array(a,n,r){child object}
@@ -136,12 +115,9 @@ module Cubic_Array(sx,sy,sz,nx,ny,nz,center)
 // n= number of objects 
 // r= radius distance 
 //
-module Radial_Array(a,n,r)
-{
- for (k=[0:n-1])
- {
- rotate([0,0,-(a*k)])
- translate([0,r,0])
- for (k = [0:$children-1]) child(k);
- }
+module Radial_Array(a,n,r){
+	for (k=[0:n-1])
+		rotate([0,0,-(a*k)])
+			translate([0,r,0])
+				children([0:$children-1]);
 }

--- a/array.scad
+++ b/array.scad
@@ -105,7 +105,7 @@ module Cubic_Array(sx,sy,sz,nx,ny,nz,center) {
 			    for(y=[1:ny])
 					for(z=[1:nz])
 						translate([x*sx,y*sy,z*sz])
-						    children([0:$children-1]);
+						    children();
 }
 
 //

--- a/array.scad
+++ b/array.scad
@@ -92,20 +92,13 @@ module Cubic_and_Radial_Array_Test()
 
 // main lib modules
 module Cubic_Array(sx,sy,sz,nx,ny,nz,center) {
-	if (center==true)
-		translate([-(((nx+1)*sx)/2),-(((ny+1)*sy)/2),-(((nz+1)*sz)/2)])
+	offset = center ? [-(((nx+1)*sx)/2),-(((ny+1)*sy)/2),-(((nz+1)*sz)/2)] : [0,0,0];
+	translate(offset)
 			for(x=[1:nx])
-				for(y=[1:ny])
-					for(z=[1:nz])
-						translate([x*sx,y*sy,z*sz])
-							children([0:$children-1],center=true);
-	else
-		translate([0,0,0])
-			for(x=[1:nx])
-			    for(y=[1:ny])
-					for(z=[1:nz])
-						translate([x*sx,y*sy,z*sz])
-						    children();
+					for(y=[1:ny])
+							for(z=[1:nz])
+									translate([x*sx,y*sy,z*sz])
+											children([0:$children-1],center);
 }
 
 //

--- a/array.scad
+++ b/array.scad
@@ -94,11 +94,9 @@ module Cubic_and_Radial_Array_Test()
 module Cubic_Array(sx,sy,sz,nx,ny,nz,center) {
 	offset = center ? [-(((nx+1)*sx)/2),-(((ny+1)*sy)/2),-(((nz+1)*sz)/2)] : [0,0,0];
 	translate(offset)
-			for(x=[1:nx])
-					for(y=[1:ny])
-							for(z=[1:nz])
-									translate([x*sx,y*sy,z*sz])
-											children([0:$children-1],center);
+		for(x=[1:nx], y=[1:ny], z=[1:nz])
+			translate([x*sx,y*sy,z*sz])
+				children();
 }
 
 //

--- a/array.scad
+++ b/array.scad
@@ -119,5 +119,5 @@ module Radial_Array(a,n,r){
 	for (k=[0:n-1])
 		rotate([0,0,-(a*k)])
 			translate([0,r,0])
-				children([0:$children-1]);
+				children();
 }

--- a/fonts.scad
+++ b/fonts.scad
@@ -24,12 +24,15 @@ module bold_2d(bold,width=0.2,resolution=8) {
   for(j=[0:$children-1]) {
     if(bold) {
       union() {
-            child(j);
-        for(i=[0:resolution-1]) assign(dx=width*cos(360*i/resolution),dy=width*sin(360*i/resolution))
-              translate([dx,dy]) child(j);
+            children(j);
+        for(i=[0:resolution-1]) {
+            dx=width*cos(360*i/resolution);
+            dy=width*sin(360*i/resolution);
+            translate([dx,dy]) children(j);
+        }
       }
     } else {
-      child(j);
+      children(j);
     }
   }
 }
@@ -47,7 +50,9 @@ module polytext(charstring,size,font,line=0,justify=1,align=-1
   char_shift_height=-char_height/2-align*char_height/2;
   char_thickness=font[0][2];
   char_index_map=search(charstring,font[2],1,1);
-  for(i=[0:len(char_index_map)-1]) assign( thisCharIndex=char_index_map[i], x_pos=i*size+line_shift_x*size/char_width) {
+  for(i=[0:len(char_index_map)-1]) {
+    thisCharIndex=char_index_map[i];
+    x_pos=i*size+line_shift_x*size/char_width;
     translate([x_pos,line*size+char_shift_height*size/char_height]) scale([size/char_width,size/char_height]) {
       if(char_thickness==0)
         bold_2d(bold,width=bold_width,resolution=bold_resolution)
@@ -578,8 +583,8 @@ module braille_ascii_spec800(inString,dot_backing=true,cell_backing=false,justif
   x_shift=thisFont[0][0];
   y_shift=thisFont[0][1];
   theseIndicies=search(inString,thisFont[2],1,1);
-  for( i=[0:len(theseIndicies)-1]) translate([i*x_shift-(1-justify)*x_shift*len(theseIndicies)/2,-y_shift*(align+1)/2]) 
-	assign(dotPattern=thisFont[2][theseIndicies[i]][6]) {
+  for( i=[0:len(theseIndicies)-1]) translate([i*x_shift-(1-justify)*x_shift*len(theseIndicies)/2,-y_shift*(align+1)/2]) {
+	dotPattern=thisFont[2][theseIndicies[i]][6];
     if(dot_backing) translate([cell_d2d_spacing/2-dot_spacing/2-dot_d/2,line_d2d_spacing/2-dot_spacing-dot_d/2,-dot_h]) 
 	cube(size=[dot_spacing+dot_d,2*dot_spacing+dot_d,dot_h],center=false);
     if(cell_backing) translate([0,0,-dot_h]) 

--- a/gridbeam.scad
+++ b/gridbeam.scad
@@ -113,11 +113,7 @@ if (mode == "dxf") {
 }
 }
 
-module translateBeam(v) {
-	for (i = [0 : $children - 1]) {
-		translate(v * beam_width) child(i);
-	}
-}
+module translateBeam(v) translate(v * beam_width) children([0 : $children - 1]);
 
 module topShelf(width, depth, corners) {
 if (mode == "model") {

--- a/involute_gears.scad
+++ b/involute_gears.scad
@@ -360,7 +360,7 @@ module gear (
 		{
 			difference ()
 			{
-				linear_exturde_flat_option(flat=flat, height=rim_thickness, convexity=10, twist=twist)
+				linear_extrude_flat_option(flat=flat, height=rim_thickness, convexity=10, twist=twist)
 				gear_shape (
 					number_of_teeth,
 					pitch_radius = pitch_radius,
@@ -375,28 +375,28 @@ module gear (
 					cylinder (r=rim_radius,h=rim_thickness-gear_thickness+1);
 			}
 			if (gear_thickness > rim_thickness)
-				linear_exturde_flat_option(flat=flat, height=gear_thickness)
+				linear_extrude_flat_option(flat=flat, height=gear_thickness)
 				circle (r=rim_radius);
 			if (flat == false && hub_thickness > gear_thickness)
 				translate ([0,0,gear_thickness])
-				linear_exturde_flat_option(flat=flat, height=hub_thickness-gear_thickness)
+				linear_extrude_flat_option(flat=flat, height=hub_thickness-gear_thickness)
 				circle (r=hub_diameter/2);
 		}
 		translate ([0,0,-1])
-		linear_exturde_flat_option(flat =flat, height=2+max(rim_thickness,hub_thickness,gear_thickness))
+		linear_extrude_flat_option(flat =flat, height=2+max(rim_thickness,hub_thickness,gear_thickness))
 		circle (r=bore_diameter/2);
 		if (circles>0)
 		{
 			for(i=[0:circles-1])
 				rotate([0,0,i*360/circles])
 				translate([circle_orbit_diameter/2,0,-1])
-				linear_exturde_flat_option(flat =flat, height=max(gear_thickness,rim_thickness)+3)
+				linear_extrude_flat_option(flat =flat, height=max(gear_thickness,rim_thickness)+3)
 				circle(r=circle_diameter/2);
 		}
 	}
 }
 
-module linear_exturde_flat_option(flat =false, height = 10, center = false, convexity = 2, twist = 0)
+module linear_extrude_flat_option(flat =false, height = 10, center = false, convexity = 2, twist = 0)
 {
 	if(flat==false)
 	{

--- a/involute_gears.scad
+++ b/involute_gears.scad
@@ -400,11 +400,11 @@ module linear_exturde_flat_option(flat =false, height = 10, center = false, conv
 {
 	if(flat==false)
 	{
-		linear_extrude(height = height, center = center, convexity = convexity, twist= twist) child(0);
+		linear_extrude(height = height, center = center, convexity = convexity, twist= twist) children(0);
 	}
 	else
 	{
-		child(0);
+		children(0);
 	}
 
 }
@@ -459,21 +459,16 @@ module involute_gear_tooth (
 
 	union ()
 	{
-		for (i=[1:res])
-		assign (
-			point1=involute (base_radius,start_angle+(stop_angle - start_angle)*(i-1)/res),
-			point2=involute (base_radius,start_angle+(stop_angle - start_angle)*i/res))
-		{
-			assign (
-				side1_point1=rotate_point (centre_angle, point1),
-				side1_point2=rotate_point (centre_angle, point2),
-				side2_point1=mirror_point (rotate_point (centre_angle, point1)),
-				side2_point2=mirror_point (rotate_point (centre_angle, point2)))
-			{
-				polygon (
-					points=[[0,0],side1_point1,side1_point2,side2_point2,side2_point1],
-					paths=[[0,1,2,3,4,0]]);
-			}
+		for (i=[1:res]) {
+			point1=involute (base_radius,start_angle+(stop_angle - start_angle)*(i-1)/res);
+			point2=involute (base_radius,start_angle+(stop_angle - start_angle)*i/res);
+			side1_point1=rotate_point (centre_angle, point1);
+			side1_point2=rotate_point (centre_angle, point2);
+			side2_point1=mirror_point (rotate_point (centre_angle, point1));
+			side2_point2=mirror_point (rotate_point (centre_angle, point2));
+			polygon (
+				points=[[0,0],side1_point1,side1_point2,side2_point2,side2_point1],
+				paths=[[0,1,2,3,4,0]]);
 		}
 	}
 }

--- a/layouts.scad
+++ b/layouts.scad
@@ -31,7 +31,7 @@
 module list(iHeight)
 {
 	for (i = [0 : $children-1]) 
-		translate([0,i*iHeight]) child(i);
+		translate([0,i*iHeight]) children(i);
 }
 module grid(iWidth,iHeight,inYDir = true,limit=3)
 {
@@ -39,6 +39,6 @@ module grid(iWidth,iHeight,inYDir = true,limit=3)
 	{
 		translate([(inYDir)? (iWidth)*(i%limit) : (iWidth)*floor(i/limit),
 					(inYDir)? (iHeight)*floor(i/limit) : (iHeight)*(i%limit)])
-					child(i);
+					children(i);
 	}
 }

--- a/multiply.scad
+++ b/multiply.scad
@@ -9,20 +9,22 @@ include <units.scad>
 
 use <utilities.scad>
 
-// TODO check that the axis parameter works as intended
-// Duplicate everything $no of times around an $axis, for $angle/360 rounds
-module spin(no, angle=360, axis=Z){
-    for (i = [1:no]){
-        rotate(normalized_axis(axis)*angle*no/i)
-            union() children([0 : $children-1]);
-    }
+// Copy everything $no of times around an $axis, spread over $angle
+// If $strict==true or $angle==360, then spacing will leave an empty at $angle,
+//  otherwise, $no will be distributed so first is at 0deg, last copy at $angle degrees
+// NOTE: $axis works (rotates around that axis), but pass parameter as lower case string
+//  eg: "x", "y", or "z". Alternatively, use units.scad vector definitions: X, Y, Z
+module spin(no, angle=360, axis=Z, strict=false){
+    divisor = (strict || angle==360) ? no : no-1;
+    for (i = [0:no-1])
+        rotate(normalized_axis(axis)*angle*i/divisor)
+            children();
 }
 
-//Doesn't work currently
-module duplicate(axis=Z) spin(no=2, axis=axis) children(0);
+// Make a copy of children by rotating around $axis by 180 degrees
+module duplicate(axis=Z) spin(no=2, axis=axis) children();
 
-module linear_multiply(no, separation, axis=Z){
-    for (i = [0:no-1]){
-        translate(i*separation*axis) children(0);
-    }
-}
+// Make $no copies along the $axis, separated by $separation
+module linear_multiply(no, separation, axis=Z)
+    for (i = [0:no-1])
+        translate(i*separation*normalized_axis(axis)) children();

--- a/multiply.scad
+++ b/multiply.scad
@@ -13,17 +13,16 @@ use <utilities.scad>
 // Duplicate everything $no of times around an $axis, for $angle/360 rounds
 module spin(no, angle=360, axis=Z){
     for (i = [1:no]){
-        rotate(normalized_axis(axis)*angle*no/i) union(){
-            for (i = [0 : $children-1]) child(i);
-        }
+        rotate(normalized_axis(axis)*angle*no/i)
+            union() children([0 : $children-1]);
     }
 }
 
 //Doesn't work currently
-module duplicate(axis=Z) spin(no=2, axis=axis) child(0);
+module duplicate(axis=Z) spin(no=2, axis=axis) children(0);
 
 module linear_multiply(no, separation, axis=Z){
     for (i = [0:no-1]){
-        translate(i*separation*axis) child(0);
+        translate(i*separation*axis) children(0);
     }
 }

--- a/polyholes.scad
+++ b/polyholes.scad
@@ -3,24 +3,21 @@
 
 // Using this holes should come out approximately right when printed
 module polyhole(h, d) {
-    n = max(round(2 * d),3);
-    rotate([0,0,180])
-        cylinder(h = h, r = (d / 2) / cos (180 / n), $fn = n);
+	n = max(round(2 * d),3);
+	rotate([0,0,180])
+		cylinder(h = h, r = (d / 2) / cos (180 / n), $fn = n);
 }
 
 module test_polyhole(){
-difference() {
-	cube(size = [100,27,3]);
-    union() {
-    	for(i = [1:10]) {
-            translate([(i * i + i)/2 + 3 * i , 8,-1])
-                polyhole(h = 5, d = i);
-                
-            assign(d = i + 0.5)
-                translate([(d * d + d)/2 + 3 * d, 19,-1])
-                    polyhole(h = 5, d = d);
-    	}
-    }
-}
+	difference() {
+		cube(size = [100,27,3]);
+		for(i = [1:10]) {
+			translate([(i * i + i)/2 + 3 * i , 8,-1])
+				polyhole(h = 5, d = i);
+			d = i + 0.5;
+			translate([(d * d + d)/2 + 3 * d, 19,-1])
+				polyhole(h = 5, d = d);
+		}
+	}
 }
 

--- a/regular_shapes.scad
+++ b/regular_shapes.scad
@@ -50,43 +50,43 @@ module regular_polygon(sides, radius)
 
 module pentagon(radius)
 {
-  reg_polygon(5,radius);
+  regular_polygon(5,radius);
 }
 
 module hexagon(radius, diameter, across_flats)
 {
   r = across_flats ? across_flats/2/cos(30) : diameter ? diameter/2 : radius;
-  reg_polygon(6,r);
+  regular_polygon(6,r);
 }
 
 module heptagon(radius)
 {
-  reg_polygon(7,radius);
+  regular_polygon(7,radius);
 }
 
 module octagon(radius)
 {
-  reg_polygon(8,radius);
+  regular_polygon(8,radius);
 }
 
 module nonagon(radius)
 {
-  reg_polygon(9,radius);
+  regular_polygon(9,radius);
 }
 
 module decagon(radius)
 {
-  reg_polygon(10,radius);
+  regular_polygon(10,radius);
 }
 
 module hendecagon(radius)
 {
-  reg_polygon(11,radius);
+  regular_polygon(11,radius);
 }
 
 module dodecagon(radius)
 {
-  reg_polygon(12,radius);
+  regular_polygon(12,radius);
 }
 
 module ring(inside_diameter, thickness){

--- a/screw.scad
+++ b/screw.scad
@@ -20,7 +20,7 @@ inner_diameter: thickness of the shaft
 module helix(pitch, length, slices=500){
     rotations = length/pitch;
     linear_extrude(height=length, center=false, convexity=10, twist=360*rotations, slices=slices, $fn=100)
-        child(0);
+        children();
 }
 
 module auger(pitch, length, outside_radius, inner_radius, taper_ratio = 0.25) {

--- a/transformations.scad
+++ b/transformations.scad
@@ -2,5 +2,5 @@
 // © 2010 by Elmo Mäntynen
 
 module local_scale(v, reference=[0, 0, 0]) {
-    translate(-reference) scale(v) translate(reference) child(0);
+    translate(-reference) scale(v) translate(reference) children();
 }

--- a/utilities.scad
+++ b/utilities.scad
@@ -50,7 +50,7 @@ module fromTo(from=[0,0,0], to=[1*m,0,0], size=[1*cm, 1*cm], align=[CENTER, CENT
         rotate(angle)
           translate( [ -endCaps[0]*size[0] - endExtras[0], size[0]*(-0.5-align[0]), size[1]*(-0.5+align[1]) ] )
             rotate(rotation)
-              scale([length, size[0], size[1]]) child();
+              scale([length, size[0], size[1]]) children();
   }
 }
 


### PR DESCRIPTION
I replaced the deprecated child() and assign() in the library. I also made a few changes while testing/validating my updates:

- applying an operation to all children, rather than only the first
- updating some modules to work properly (or as I think they should work - check multiply.scad commit 87cf713d25b5a1c5531040ce020c6e55c951f19)
- also fixed deprecated warnings in regular_shapes.scad  - see Issue #69 

I tried to make the changes clear in each commit comment.
Thanks for a great library!