### PR TITLE
Add rack() module to involute_gears.

### DIFF
--- a/involute_gears.scad
+++ b/involute_gears.scad
@@ -396,6 +396,46 @@ module gear (
 	}
 }
 
+module rack(
+		number_of_teeth=15,
+		circular_pitch=false, diametral_pitch=false,
+		pressure_angle=28,
+		clearance=0.2,
+		rim_thickness=8,
+		rim_width=5,
+		flat=false)
+{
+
+	if (circular_pitch==false && diametral_pitch==false)
+		echo("MCAD ERROR: gear module needs either a diametral_pitch or circular_pitch");
+
+	//Convert diametrial pitch to our native circular pitch
+	circular_pitch = (circular_pitch!=false?circular_pitch:180/diametral_pitch);
+	pitch = circular_pitch / 180 * PI;
+
+	addendum = circular_pitch / 180;
+	dedendum = addendum + clearance;
+	pitch_slope = tan(pressure_angle);
+
+	linear_exturde_flat_option(flat=flat, height=rim_thickness)
+		union()
+		{
+			translate([0,-dedendum-rim_width/2])
+				square([number_of_teeth*pitch, rim_width],center=true);
+
+			p1 = pitch / 4 + pitch_slope * dedendum;
+			p2 = pitch / 4 - pitch_slope * addendum;
+			for(i=[1:number_of_teeth])
+				translate([pitch*(i-number_of_teeth/2-0.5),0])
+					polygon(points=[
+							[-p1,-dedendum],
+							[p1,-dedendum],
+							[p2,addendum],
+							[-p2,addendum]
+					]);
+		}
+}
+
 module linear_exturde_flat_option(flat =false, height = 10, center = false, convexity = 2, twist = 0)
 {
 	if(flat==false)
@@ -559,6 +599,12 @@ module test_gears()
 				circular_pitch=500,
 				circles=5,
 				hub_diameter=2*8.88888889);
+
+			translate ([-37.5,0,0])
+			rotate ([0,0,-90])
+			rack (
+				circular_pitch=500
+			     );
 
 			translate ([0,0,10])
 			{


### PR DESCRIPTION
This PR adds a `rack()` module to the `involute_gears()` module. It is basically a section of the rim of a gear of infinite teeth.

It has a subset or the `gear()` arguments:
* `number_of_teeth`: will affect the length of the rack.
* `circular_pitch` or `diametral_pitch`: must match that of the gear.
* `pressure_angle`: must match that of the gear.
* `rim_thickness`: there is no disk or hub so this is the only thickness.
* `rim_width`: width of the flat ribbon behind the teeth.
* `clearance`
* `flat`

The other ones do not make much sense for a rack.

A rack and a gear will match if they have the same pitch and pressure angle. The origin point or a rack is set to the middle point of the "pitch line", so to align it with a gear, just move it to the pitch circle of the gear.

I've added a small rack to the `test_gears()` module, but feel free to change of remove it if it is not appropriate.

![test_gear](https://user-images.githubusercontent.com/1128630/77658036-6801e480-6f76-11ea-8a8d-63e1f7602f57.png)
