### PR TITLE
Fix len() conversion warnings

### DIFF
--- a/shapes/2Dshapes.scad
+++ b/shapes/2Dshapes.scad
@@ -270,14 +270,14 @@ module donutSlice(innerSize, outerSize, start_angle, end_angle)
     difference()
     {
         pieSlice(outerSize, start_angle, end_angle);
-        if(len(innerSize) > 1) ellipse(innerSize[0]*2, innerSize[1]*2);
+        if(is_list(innerSize)) ellipse(innerSize[0]*2, innerSize[1]*2);
         else circle(innerSize);
     }
 }
 module pieSlice(size, start_angle, end_angle) //size in radius(es)
 {
-    rx = ((len(size) > 1)? size[0] : size);
-    ry = ((len(size) > 1)? size[1] : size);
+    rx = (is_list(size)? size[0] : size);
+    ry = (is_list(size)? size[1] : size);
     trx = rx* sqrt(2) + 1;
     try = ry* sqrt(2) + 1;
     a0 = (4 * start_angle + 0 * end_angle) / 4;
@@ -287,7 +287,7 @@ module pieSlice(size, start_angle, end_angle) //size in radius(es)
     a4 = (0 * start_angle + 4 * end_angle) / 4;
     if(end_angle > start_angle)
         intersection() {
-		if (len(size) > 1)
+		if (is_list(size))
             ellipse(rx*2, ry*2);
 		else
 			circle(rx);

--- a/shapes/2Dshapes.scad
+++ b/shapes/2Dshapes.scad
@@ -286,19 +286,20 @@ module pieSlice(size, start_angle, end_angle) //size in radius(es)
     a3 = (1 * start_angle + 3 * end_angle) / 4;
     a4 = (0 * start_angle + 4 * end_angle) / 4;
     if(end_angle > start_angle)
-        intersection() {
-		if (is_list(size))
-            ellipse(rx*2, ry*2);
-		else
-			circle(rx);
-        polygon([
-            [0, 0],
-            [trx * cos(a0), try * sin(a0)],
-            [trx * cos(a1), try * sin(a1)],
-            [trx * cos(a2), try * sin(a2)],
-            [trx * cos(a3), try * sin(a3)],
-            [trx * cos(a4), try * sin(a4)],
-            [0, 0]
-       ]);
-    }
+        intersection()
+        {
+            if (is_list(size))
+                ellipse(rx*2, ry*2);
+            else
+                circle(rx);
+            polygon([
+                [0, 0],
+                [trx * cos(a0), try * sin(a0)],
+                [trx * cos(a1), try * sin(a1)],
+                [trx * cos(a2), try * sin(a2)],
+                [trx * cos(a3), try * sin(a3)],
+                [trx * cos(a4), try * sin(a4)],
+                [0, 0]
+            ]);
+        }
 }


### PR DESCRIPTION
This fixes the len() parameter conversion warnings, at least in the donutSlice and pieSlice modules. Also cleans up some whitespace cos why not.