### PR TITLE
Extended boxes.scad with a module that produces rounded cubes with two different radii

### DIFF
--- a/boxes.scad
+++ b/boxes.scad
@@ -1,15 +1,18 @@
 // Library: boxes.scad
 // Version: 1.0
-// Author: Marius Kintel
+// Author: Marius Kintel, Sebastian Boschert
 // Copyright: 2010
 // License: 2-clause BSD License (http://opensource.org/licenses/BSD-2-Clause)
 
 // 
 // roundedCube([x, y, z], r, sidesonly=true/false, center=true/false);
 // roundedCube(x, r, sidesonly=true/false, center=true/false);
+// roundedCubeDual([x, y, z], r1, r2, center=true/false);
+// roundedCubeDual(x, r1, r2, center=true/false);
 
 // EXAMPLE USAGE:
 // roundedCube([20, 30, 40], 5, true, true);
+// roundedCubeDual([40, 40, 20], 2, 0.8, true);
 
 // Only for backwards compatibility with existing scripts, (always centered, radius instead of consistent "r" naming.
 module roundedBox(size, radius, sidesonly)
@@ -20,26 +23,31 @@ module roundedBox(size, radius, sidesonly)
 
 // New implementation
 module roundedCube(size, r, sidesonly, center) {
+  roundedCubeDual(size, r, sidesonly ? 0 : r, center);
+}
+
+// Even newer implementation with different horizontal and vertical radii
+module roundedCubeDual(size, r1, r2, center) {
   s = is_list(size) ? size : [size,size,size];
   translate(center ? -s/2 : [0,0,0]) {
-    if (sidesonly) {
+    if (r2 == 0) {
       hull() {
-        translate([     r,     r]) cylinder(r=r, h=s[2]);
-        translate([     r,s[1]-r]) cylinder(r=r, h=s[2]);
-        translate([s[0]-r,     r]) cylinder(r=r, h=s[2]);
-        translate([s[0]-r,s[1]-r]) cylinder(r=r, h=s[2]);
+        translate([     r1,     r1]) cylinder(r=r1, h=s[2]);
+        translate([     r1,s[1]-r1]) cylinder(r=r1, h=s[2]);
+        translate([s[0]-r1,     r1]) cylinder(r=r1, h=s[2]);
+        translate([s[0]-r1,s[1]-r1]) cylinder(r=r1, h=s[2]);
       }
-    }
-    else {
+    } else {
+      resize_vector = [2*r1, 2*r1, 2*r2];
       hull() {
-        translate([     r,     r,     r]) sphere(r=r);
-        translate([     r,     r,s[2]-r]) sphere(r=r);
-        translate([     r,s[1]-r,     r]) sphere(r=r);
-        translate([     r,s[1]-r,s[2]-r]) sphere(r=r);
-        translate([s[0]-r,     r,     r]) sphere(r=r);
-        translate([s[0]-r,     r,s[2]-r]) sphere(r=r);
-        translate([s[0]-r,s[1]-r,     r]) sphere(r=r);
-        translate([s[0]-r,s[1]-r,s[2]-r]) sphere(r=r);
+        translate([     r1,      r1,      r2]) resize(resize_vector) sphere(r=1);
+        translate([     r1,      r1, s[2]-r2]) resize(resize_vector) sphere(r=1);
+        translate([     r1, s[1]-r1,      r2]) resize(resize_vector) sphere(r=1);
+        translate([     r1, s[1]-r1, s[2]-r2]) resize(resize_vector) sphere(r=1);
+        translate([s[0]-r1,      r1,      r2]) resize(resize_vector) sphere(r=1);
+        translate([s[0]-r1,      r1, s[2]-r2]) resize(resize_vector) sphere(r=1);
+        translate([s[0]-r1, s[1]-r1,      r2]) resize(resize_vector) sphere(r=1);
+        translate([s[0]-r1, s[1]-r1, s[2]-r2]) resize(resize_vector) sphere(r=1);
       }
     }
   }


### PR DESCRIPTION
Some people (including myself) prefer boxes with rounded corners that have different radii on the horizontal and vertical axes.

Previously, all one could do was this:
![boxes_old](https://user-images.githubusercontent.com/21045160/119148591-ed830680-ba4c-11eb-966c-a70001a47919.png)

I have added a new module that enables users to do something like this instead. Please note the smaller radius on the top/bottom compared to the bigger radius on the sides of the box.
![boxes_new](https://user-images.githubusercontent.com/21045160/119149278-a9dccc80-ba4d-11eb-9356-d7c37577cd8f.png)

I needed to add a new module parameter for the second radius. On the other hand, the `sidesonly` parameter is rather pointless in this scenario.

So I made a new module with my changes and made the old implementation call the new one with different parameters in an effort to avoid duplicating code.

Please let me know if you have any questions or if you feel like I should change something.